### PR TITLE
[feat] Docker 설정을 위한 docker-compose, Dockerfile 파일 추가

### DIFF
--- a/sport_companion/.gitignore
+++ b/sport_companion/.gitignore
@@ -27,6 +27,8 @@ out/
 !**/src/test/**/out/
 /module-api/src/main/resources/application.yml
 /module-batch/src/main/resources/application.yml
+/module-api/src/main/resources/application-*.yml
+/module-batch/src/main/resources/application-*.yml
 
 ### NetBeans ###
 /nbproject/private/
@@ -37,3 +39,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### docker ###
+.env

--- a/sport_companion/Dockerfile
+++ b/sport_companion/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:17-jdk-alpine
+
+ARG MODULE_NAME
+COPY ${MODULE_NAME}/build/libs/${MODULE_NAME}-0.0.1-SNAPSHOT.jar sport_companion.jar
+
+ENTRYPOINT ["java", "-jar", "/sport_companion.jar"]

--- a/sport_companion/docker-compose.yml
+++ b/sport_companion/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       mysql:
         condition: service_healthy
     environment:
-      - SPRING_PROFILES_ACTIVE=docker
+      - SPRING_PROFILES_ACTIVE=prod
     ports:
       - "8080:8080"
     networks:

--- a/sport_companion/docker-compose.yml
+++ b/sport_companion/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.3'
+
+services:
+  mysql:
+    image: mysql:9
+    volumes:
+      - sport_data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+    ports:
+      - "3306:3306"
+    restart: always
+    healthcheck:
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      timeout: 20s
+      retries: 10
+    networks:
+      - sport-network
+
+  api-module:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        MODULE_NAME: module-api
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+    ports:
+      - "8080:8080"
+    networks:
+      - sport-network
+
+networks:
+  sport-network:
+    driver: bridge
+
+volumes:
+  sport_data:


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
- **.gitignore**
  - profile 별 설정 파일 (application-*.yml) 추가
  - 환경 변수 설정 파일 (.env) 추가
- **docker-compose.yml**
  - mysql
    - mysql 9버전 이미지, 3306 포트로 생성
    - .env 파일 기반으로 루트 패스워드와 데이터베이스 생성
    - api-module에서 mysql이 실행된 다음 실행될 수 있도록 헬스체크 수행
    - 데이터 저장을 위해 volume 설정
  - api-module
    - Dockerfile에 MODULE_NAME으로 module-api를 넘겨주어 실행되는 jar파일을 이미지로 사용
    - mysql 컨테이너가 healthy 상태일 때 실행되도록 설정
    - active profile로 prod(application-prod) 사용
- **Dockerfile**
  - docker-compose에서 설정한 MODULE_NAME을 바탕으로 jar 파일을 실행할 수 있도록 명령어 추가

## 스크린샷
![image](https://github.com/user-attachments/assets/0dbe8525-a9cd-4f13-81e3-5751f2f1498b)
![image](https://github.com/user-attachments/assets/e6059701-d975-4a17-9464-f6e4e6dd6f9b)

## 주의사항
- **application.yml** 파일 수정 필요 (스크린샷 참고)
  - application-dev : `spring.datasource.url = jdbc:mysql://localhost:3306/sport_companion`
  - application-prod: `spring.datasource.url = jdbc:mysql://mysql:3306/sport_companion`
  - application : `spring.profiles.active = dev`

- 프로젝트 루트에 **.env** 파일 추가하여 MYSQL_ROOT_PASSWORD, MYSQL_DATABASE 설정 (스크린샷 참고)

Closes #7
