### PR TITLE
[feat] cors 설정, swagger 개발 환경 추가 및 JwtFilter 클래스 수정

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtFilter.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtFilter.java
@@ -2,6 +2,7 @@ package com.service.sport_companion.api.auth.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.service.sport_companion.domain.model.type.TokenType;
+import com.service.sport_companion.domain.model.type.UrlType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,6 +11,7 @@ import java.io.IOException;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.AntPathMatcher;
@@ -70,12 +72,12 @@ public class JwtFilter extends OncePerRequestFilter {
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");
 
-//    // CORS 헤더 추가
-//    response.setHeader("Access-Control-Allow-Origin", url);
-//    response.setHeader("Access-Control-Allow-Credentials", "true");
-//    response.setHeader("Access-Control-Allow-Methods", "GET,HEAD,POST,DELETE,TRACE,OPTIONS,PATCH,PUT");
-//    response.setHeader("Access-Control-Allow-Headers", "*");
-//    response.setHeader("Access-Control-Expose-Headers", "access-token, Location");
+    // CORS 헤더 추가
+    response.setHeader("Access-Control-Allow-Origin", UrlType.FRONT_VERCEL_URL.getUrl());
+    response.setHeader("Access-Control-Allow-Credentials", "true");
+    response.setHeader("Access-Control-Allow-Methods", "GET,HEAD,POST,DELETE,TRACE,OPTIONS,PATCH,PUT");
+    response.setHeader("Access-Control-Allow-Headers", "*");
+    response.setHeader("Access-Control-Expose-Headers", "access, Location");
 
     Map<String, String> body = Map.of("message", "유효하지 않은 Access Token");
     response.getWriter().write(objectMapper.writeValueAsString(body));
@@ -86,6 +88,11 @@ public class JwtFilter extends OncePerRequestFilter {
     AntPathMatcher pathMatcher = new AntPathMatcher();
     String method = request.getMethod();
     String path = request.getRequestURI();
+
+    // 1. Options 요청 검증
+    if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+      return true;
+    }
 
     log.info("method >>> {} request uri >>> {}", method, path);
     // 2. 예외 경로 검증

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SwaggerConfig.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SwaggerConfig.java
@@ -1,7 +1,12 @@
 package com.service.sport_companion.api.config;
 
+import com.service.sport_companion.domain.model.type.TokenType;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,20 +16,20 @@ public class SwaggerConfig {
   @Bean
   public OpenAPI customOpenAPI() {
     return new OpenAPI()
+        .addServersItem(new Server().url("https://api.sport-companion.site/").description("Production 전용"))
         .addServersItem(new Server().url("http://localhost:8080/").description("Localhost 전용"))
-
-        // Jwt 도입 후 작성할 예정
-//        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
-//        .components(new Components()
-//            .addSecuritySchemes("bearerAuth",
-//                new SecurityScheme()
-//                    .name()
-//                    .type(Type.APIKEY)
-//                    .in(SecurityScheme.In.HEADER)
-//                    .bearerFormat("JWT")))
+        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+        .components(new Components()
+            .addSecuritySchemes("bearerAuth",
+                new SecurityScheme()
+                    .name(TokenType.ACCESS.getValue())
+                    .type(Type.APIKEY)
+                    .in(SecurityScheme.In.HEADER)
+                    .bearerFormat("JWT")))
         .info(new Info()
             .title("sport_companion API")
             .version("API v1.0")
             .description("API documentation"));
   }
 }
+

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/WebMvcConfig.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/WebMvcConfig.java
@@ -1,0 +1,27 @@
+package com.service.sport_companion.api.config;
+
+import com.service.sport_companion.domain.model.type.TokenType;
+import com.service.sport_companion.domain.model.type.UrlType;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+  private static final String ALLOW_METHOD_NAMES = "GET,HEAD,POST,DELETE,TRACE,OPTIONS,PATCH,PUT";
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+
+    registry.addMapping("/**") // CORS 설정을 모든 URL에 적용
+
+        .allowedOrigins(UrlType.FRONT_VERCEL_URL.getUrl())
+        .allowedMethods(ALLOW_METHOD_NAMES.split(","))  // 허용할 HTTP Method 목록
+        .allowedHeaders("*")        // 모든 HTTP header 허용
+        .allowCredentials(true)     // 자격 증명 허용
+        .exposedHeaders(TokenType.ACCESS.getValue(), HttpHeaders.LOCATION);   // 클라이언트에 노출할 헤더 목록
+  }
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/UrlType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/UrlType.java
@@ -10,6 +10,7 @@ public enum UrlType {
   RANDOM_NICKNAME_URL("https://www.rivestsoft.com/nickname/getRandomNickname.ajax"),
   SIGNUP_URL("http://localhost:3000/signUp/success"),
   LOGIN_URL("http://localhost:3000"),
+  FRONT_VERCEL_URL("https://front-end-jet-psi.vercel.app")
   ;
 
   private final String url;


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
WebMvcConfig
- allowedOrigins : https://front-end-jet-psi.vercel.app/ 경로 허용
- allowedMethods : “GET,HEAD,POST,DELETE,TRACE,OPTIONS,PATCH,PUT” 메서드 허용
- allowedHeaders : 모든 HTTP header 허용
- allowCredentials : CORS 요청에 자격 증명 허용(쿠키 세션등)
- exposedHeaders : 서버에서 클라이언트로 응답할 때 클라이언트가 접근할 수 있도록 노출할 헤더 정의

SwaggerConfig
- 서버 도메인 주소를 추가 하면서 서버 Swagger 추가

JwtFilter
- access 토큰 만료 응답시 Cors 헤더 추가
- Option 요청 필터 검증 제외

## 스크린샷

## 주의사항

Closes #17 
