### PR TITLE
[feat] 닉네임 중복 검증 API 구현

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/UserHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/UserHandler.java
@@ -56,4 +56,11 @@ public class UserHandler {
     return usersRepository.findByUserId(userId)
         .orElseThrow(() -> new GlobalException(FailedResultType.USER_NOT_FOUND));
   }
+
+  /**
+   * nickname 존재 여부 확인 후 반환
+   */
+  public boolean existsByNickname(String nickname) {
+    return usersRepository.existsByNickname(nickname);
+  }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                 "/swagger-resources/**").permitAll()
             .requestMatchers("/",
                 "/api/v1/auth/kakao",
+                "/api/v1/auth/check-nickname/**",
                 "/favicon.ico").permitAll()
             .anyRequest().authenticated());
 

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/AuthController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/AuthController.java
@@ -1,7 +1,10 @@
 package com.service.sport_companion.api.controller;
 
 import com.service.sport_companion.api.service.AuthService;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.type.SuccessResultType;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotBlank;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +12,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,4 +38,15 @@ public class AuthController {
     return ResponseEntity.status(HttpStatus.FOUND).headers(headers).build();
   }
 
+  @GetMapping("/check-nickname/{nickname}")
+  public ResponseEntity<ResultResponse> checkNickname(
+    @NotBlank(message = "닉네임을 입력해 주세요.") @PathVariable("nickname") String nickname) {
+
+    boolean isValidNickname = authService.checkNickname(nickname);
+
+    SuccessResultType resultType = (isValidNickname) ?
+      SuccessResultType.AVAILABLE_NICKNAME : SuccessResultType.UNAVAILABLE_NICKNAME;
+
+    return ResponseEntity.ok(new ResultResponse(resultType, isValidNickname));
+  }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
@@ -1,9 +1,13 @@
 package com.service.sport_companion.api.service;
 
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
 
   // 카카오 회원가입 or 로그인
   String oAuthForKakao(String code, HttpServletResponse response);
+
+  // 닉네임 중복 확인
+  boolean checkNickname(String nickname);
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
@@ -1,6 +1,5 @@
 package com.service.sport_companion.api.service;
 
-import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
@@ -23,7 +23,6 @@ public class AuthServiceImpl implements AuthService {
   private final KakaoAuthHandler kakaoAuthHandler;
   private final UserHandler userHandler;
   private final JwtUtil jwtUtil;
-  private final UsersRepository usersRepository;
 
   @Override
   public String oAuthForKakao(String code, HttpServletResponse response) {
@@ -63,6 +62,6 @@ public class AuthServiceImpl implements AuthService {
 
   @Override
   public boolean checkNickname(String nickname) {
-    return !usersRepository.existsByNickname(nickname);
+    return !userHandler.existsByNickname(nickname);
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
@@ -8,7 +8,6 @@ import com.service.sport_companion.domain.entity.UsersEntity;
 import com.service.sport_companion.domain.model.auth.KakaoUserDetailsDTO;
 import com.service.sport_companion.domain.model.type.TokenType;
 import com.service.sport_companion.domain.model.type.UrlType;
-import com.service.sport_companion.domain.repository.UsersRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
@@ -8,6 +8,7 @@ import com.service.sport_companion.domain.entity.UsersEntity;
 import com.service.sport_companion.domain.model.auth.KakaoUserDetailsDTO;
 import com.service.sport_companion.domain.model.type.TokenType;
 import com.service.sport_companion.domain.model.type.UrlType;
+import com.service.sport_companion.domain.repository.UsersRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +23,7 @@ public class AuthServiceImpl implements AuthService {
   private final KakaoAuthHandler kakaoAuthHandler;
   private final UserHandler userHandler;
   private final JwtUtil jwtUtil;
+  private final UsersRepository usersRepository;
 
   @Override
   public String oAuthForKakao(String code, HttpServletResponse response) {
@@ -57,5 +59,10 @@ public class AuthServiceImpl implements AuthService {
         .queryParam(TokenType.REFRESH.getValue(), refresh)
         .build()
         .toUriString();
+  }
+
+  @Override
+  public boolean checkNickname(String nickname) {
+    return !usersRepository.existsByNickname(nickname);
   }
 }

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/controller/AuthControllerTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/controller/AuthControllerTest.java
@@ -1,0 +1,79 @@
+package com.service.sport_companion.api.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.service.sport_companion.api.service.AuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class AuthControllerTest {
+
+  private MockMvc mockMvc;
+
+  @Mock
+  private AuthService authService;
+
+  @InjectMocks
+  private AuthController authController;
+
+  private final String baseUrl = "/api/v1/auth";
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+    mockMvc = MockMvcBuilders.standaloneSetup(authController).build();
+  }
+
+  @Test
+  @DisplayName("checkNickname : 사용 가능한 닉네임 확인")
+  void checkNickname_AvailableNickname() throws Exception {
+    // given
+    String nickname = "validNickname";
+    boolean isValidNickname = true;
+
+    given(authService.checkNickname(nickname)).willReturn(isValidNickname);
+
+    // when & then
+    mockMvc.perform(get(baseUrl + "/check-nickname/{nickname}", nickname))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.message").value("사용 가능한 닉네임입니다."))
+      .andExpect(jsonPath("$.data").value(isValidNickname))
+      .andDo(print());
+  }
+
+  @Test
+  @DisplayName("checkNickname : 사용 불가능한(중복) 닉네임 확인")
+  void checkNickname_UnavailableNickname() throws Exception {
+    // given
+    String nickname = "invalidNickname";
+    boolean isValidNickname = false;
+
+    given(authService.checkNickname(nickname)).willReturn(isValidNickname);
+
+    // when & then
+    mockMvc.perform(get(baseUrl + "/check-nickname/{nickname}", nickname))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.message").value("이미 사용 중인 닉네임입니다."))
+      .andExpect(jsonPath("$.data").value(isValidNickname))
+      .andDo(print());
+  }
+
+  @Test
+  @DisplayName("checkNickname : 사용 불가능한(빈 값) 닉네임 확인")
+  void checkNickname_BlankNickname() throws Exception {
+    // when & then
+    mockMvc.perform(get(baseUrl + "/check-nickname/{nickname}", " "))
+      .andExpect(status().isBadRequest())
+      .andDo(print());
+  }
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -11,6 +11,8 @@ public enum SuccessResultType {
   // Auth
   SUCCESS_SIGNUP(HttpStatus.CREATED, "회원가입 성공!"),
   SUCCESS_LOGIN(HttpStatus.OK, "로그인 성공!"),
+  AVAILABLE_NICKNAME(HttpStatus.OK, "사용 가능한 닉네임입니다."),
+  UNAVAILABLE_NICKNAME(HttpStatus.OK, "이미 사용 중인 닉네임입니다.")
 
   ;
 


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
**AuthController**
- checkNickname : AuthService를 통해 닉네임이 사용중인지 확인하고, 사용 여부에 따라 알맞은 상태값을 반환한다.

**AuthService**
- checkNickname : UsersRepository를 통해 Users 테이블에 해당 닉네임이 존재하는지 확인하고, 존재하면 false 존재하지 않으면 true를 반환한다.

**SuccessResultType**
- 사용 가능한 닉네임(AVAILABLE_NICKNAME), 사용 불가능한 닉네임(UNAVAILABLE_NICKNAME) 반환 타입 추가

**SecurityConfig**
- 닉네임 중복 검증 URL("/api/v1/auth/check-nickname/**") 인증없이 접근 허용 설정

**AuthControllerTest**
- AuthController checkNickname 테스트 구현 : 사용 가능한 닉네임 / 사용 불가능한 닉네임 / 공백 값 닉네임 요청

## 스크린샷

## 주의사항

Closes #14
