### PR TITLE
[feat] 모든 구단 조회 API 구현

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtFilter.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtFilter.java
@@ -67,6 +67,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
   // Access-Token 만료시 403 반환
   private void setResponse(HttpServletResponse response) throws IOException {
+    log.info("setResponse");
     ObjectMapper objectMapper = new ObjectMapper();
     response.setStatus(HttpServletResponse.SC_FORBIDDEN);
     response.setContentType("application/json");
@@ -104,6 +105,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     return pathMatcher.match("/", requestURI)
         || pathMatcher.match("/api/v1/auth/**", requestURI)
+        || pathMatcher.match("/api/v1/clubs/all", requestURI)
         || pathMatcher.match("/v3/api-docs/**", requestURI)
         || pathMatcher.match("/swagger-ui/**", requestURI)
         || pathMatcher.match("/swagger-ui.html", requestURI)

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
@@ -46,8 +46,8 @@ public class SecurityConfig {
                 "/swagger-ui.html",
                 "/swagger-resources/**").permitAll()
             .requestMatchers("/",
-                "/api/v1/auth/kakao",
-                "/api/v1/auth/check-nickname/**",
+                "/api/v1/auth/**",
+                "/api/v1/clubs/all",
                 "/favicon.ico").permitAll()
             .anyRequest().authenticated());
 

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/ClubsController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/ClubsController.java
@@ -1,0 +1,25 @@
+package com.service.sport_companion.api.controller;
+
+import com.service.sport_companion.api.service.ClubsService;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/clubs")
+public class ClubsController {
+
+  private final ClubsService clubsService;
+
+  @GetMapping("/all")
+  public ResponseEntity<ResultResponse> getAllClubs() {
+
+    ResultResponse response = clubsService.getAllClubList();
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/ClubsService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/ClubsService.java
@@ -1,0 +1,8 @@
+package com.service.sport_companion.api.service;
+
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+
+public interface ClubsService {
+
+  ResultResponse getAllClubList();
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/ClubsServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/ClubsServiceImpl.java
@@ -1,0 +1,30 @@
+package com.service.sport_companion.api.service.impl;
+
+import com.service.sport_companion.api.service.ClubsService;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.clubs.Clubs;
+import com.service.sport_companion.domain.model.type.SuccessResultType;
+import com.service.sport_companion.domain.repository.ClubsRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ClubsServiceImpl implements ClubsService {
+
+  private final ClubsRepository clubsRepository;
+
+  // 모든 구단 조회
+  @Override
+  public ResultResponse getAllClubList() {
+    // 다른 종목 추가시 수정할 예정
+    List<Clubs> clubList = clubsRepository.findAll().stream()
+        .map(clubsEntity -> new Clubs(clubsEntity.getClubName(), clubsEntity.getEmblemImg()))
+        .toList();
+
+    return new ResultResponse(SuccessResultType.SUCCESS_GET_ALL_CLUBS_LIST, clubList);
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/utils/HttpCookieUtil.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/utils/HttpCookieUtil.java
@@ -1,11 +1,11 @@
 package com.service.sport_companion.api.utils;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
-import jakarta.servlet.http.Cookie;
 
 public class HttpCookieUtil {
 

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/ClubsServiceImplTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/ClubsServiceImplTest.java
@@ -1,0 +1,76 @@
+package com.service.sport_companion.api.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.entity.ReservationSiteEntity;
+import com.service.sport_companion.domain.entity.SportsEntity;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.clubs.Clubs;
+import com.service.sport_companion.domain.model.type.SuccessResultType;
+import com.service.sport_companion.domain.repository.ClubsRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClubsServiceImplTest {
+
+  @Mock
+  private ClubsRepository clubsRepository;
+
+  @InjectMocks
+  private ClubsServiceImpl clubsService;
+
+  private List<ClubsEntity> clubsEntities;
+  private List<Clubs> clubsList;
+
+  @BeforeEach
+  void setUp() {
+    // 가짜 ClubsEntity 리스트 생성
+    clubsEntities = List.of(
+        ClubsEntity.builder()
+            .clubId(1L)
+            .clubName("KIA 타이거즈")
+            .clubStadium("광주 기아 챔피언스 필드")
+            .sports(SportsEntity.builder().sportId(1L).build())
+            .emblemImg("imageUrl1")
+            .introduction(null)
+            .reservationSite(ReservationSiteEntity.builder().reservationSiteId(1L).build())
+            .build(),
+        ClubsEntity.builder()
+            .clubId(2L)
+            .clubName("삼성 라이온즈")
+            .clubStadium("대구 삼성 라이온즈 파크")
+            .sports(SportsEntity.builder().sportId(1L).build())
+            .emblemImg("imageUrl2")
+            .introduction(null)
+            .reservationSite(ReservationSiteEntity.builder().reservationSiteId(1L).build())
+            .build()
+    );
+
+    // 가짜 Clubs 리스트 생성
+    clubsList = clubsEntities.stream()
+        .map(clubsEntity -> new Clubs(clubsEntity.getClubName(), clubsEntity.getEmblemImg()))
+        .toList();
+  }
+
+  @Test
+  @DisplayName("모든 클럽 리스트 가져오기 성공")
+  void getAllClubListSuccessfully() {
+    // given
+    when(clubsRepository.findAll()).thenReturn(clubsEntities);
+
+    // when
+    ResultResponse resultResponse = clubsService.getAllClubList();
+
+    // then
+    assertEquals(SuccessResultType.SUCCESS_GET_ALL_CLUBS_LIST.getStatus(), resultResponse.getStatus());
+  }
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/ClubsEntity.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/ClubsEntity.java
@@ -26,9 +26,16 @@ public class ClubsEntity {
   @JoinColumn(name = "sport_id", nullable = false)
   private SportsEntity sports;
 
+  @ManyToOne
+  @JoinColumn(name = "reservation_site_id", nullable = false)
+  private ReservationSiteEntity reservationSite;
+
   private String clubName;
+
+  private String introduction;
 
   private String clubStadium;
 
-  private String reservationSite;
+  private String emblemImg;
+
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/ReservationSiteEntity.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/ReservationSiteEntity.java
@@ -1,0 +1,27 @@
+package com.service.sport_companion.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "ReservationSite")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class ReservationSiteEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long reservationSiteId;
+
+  private String siteName;
+
+  private String siteUrl;
+
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/clubs/Clubs.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/clubs/Clubs.java
@@ -1,0 +1,12 @@
+package com.service.sport_companion.domain.model.dto.response.clubs;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Clubs {
+
+  String clubName;
+  String emblemImg;
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -12,7 +12,10 @@ public enum SuccessResultType {
   SUCCESS_SIGNUP(HttpStatus.CREATED, "회원가입 성공!"),
   SUCCESS_LOGIN(HttpStatus.OK, "로그인 성공!"),
   AVAILABLE_NICKNAME(HttpStatus.OK, "사용 가능한 닉네임입니다."),
-  UNAVAILABLE_NICKNAME(HttpStatus.OK, "이미 사용 중인 닉네임입니다.")
+  UNAVAILABLE_NICKNAME(HttpStatus.OK, "이미 사용 중인 닉네임입니다."),
+
+  //Club
+  SUCCESS_GET_ALL_CLUBS_LIST(HttpStatus.OK, "모든 구단 조회 성공!"),
 
   ;
 

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/ReservationSiteRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/ReservationSiteRepository.java
@@ -1,0 +1,10 @@
+package com.service.sport_companion.domain.repository;
+
+import com.service.sport_companion.domain.entity.ReservationSiteEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReservationSiteRepository extends JpaRepository<ReservationSiteEntity, Long> {
+
+}


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 모든 구단 조회 API 구현
- 구현 한 클래스 
   - Clubs 관련 Http 요청 및  응답을 반환 해주는 ClubsController 구현
   - Clubs 관련 비즈니스 로직을 처리할 ClubsService & ClubsServiceImpl 클래스 구현
   - 예메 사이트 관련 데이터 저장을 위해 [ReservationSiteEntity, ReservationSiteRepository 클래스 구현
   - 반환시 데이터를 담을 Clubs DTO 클래스 구현
   - ClubsServiceImpl 클래스 테스트를 위해 테스트 클래스 구현

- 수정한 클래스
   - JwtFilter & SecurityConfig 클래스 구단 조회 요청 경로 접근 권한 허용 설정
   - ClubsEntity 컬럼 수정 및 추가
   - SuccessResultType 조회 성공시 상태 코드 값 추가

## 스크린샷

## 주의사항

Closes #20 
