### PR TITLE
[feat] ArgumentResolver로 API 요청 사용자 정보 조회 기능 추가

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/CallUserResolver.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/CallUserResolver.java
@@ -1,0 +1,45 @@
+package com.service.sport_companion.api.auth.jwt;
+
+import com.service.sport_companion.domain.model.annotation.CallUser;
+import com.service.sport_companion.domain.model.type.TokenType;
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class CallUserResolver implements HandlerMethodArgumentResolver {
+
+  private final JwtUtil jwtUtil;
+
+  // CallUser 어노테이션이 붙은 메서드 파라미터를 대상으로 resolver 수행
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.getParameterAnnotation(CallUser.class) != null;
+  }
+
+  // request로부터 토큰을 추출하여 userId를 반환
+  @Override
+  public Long resolveArgument(@Nullable MethodParameter parameter,
+    ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+    WebDataBinderFactory binderFactory) {
+
+    HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+    String tokenHeader = request.getHeader(TokenType.ACCESS.getValue());
+
+    if (tokenHeader == null || !tokenHeader.startsWith("Bearer ")) {
+      return null;
+    }
+
+    String accessToken = tokenHeader.substring(7);
+
+    return jwtUtil.getUserId(accessToken);
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/WebMvcConfig.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/WebMvcConfig.java
@@ -1,17 +1,23 @@
 package com.service.sport_companion.api.config;
 
+import com.service.sport_companion.api.auth.jwt.CallUserResolver;
 import com.service.sport_companion.domain.model.type.TokenType;
 import com.service.sport_companion.domain.model.type.UrlType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 
 @Configuration
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 
   private static final String ALLOW_METHOD_NAMES = "GET,HEAD,POST,DELETE,TRACE,OPTIONS,PATCH,PUT";
+  private final CallUserResolver callUserResolver;
 
   @Override
   public void addCorsMappings(CorsRegistry registry) {
@@ -26,5 +32,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
         .allowedHeaders("*")        // 모든 HTTP header 허용
         .allowCredentials(true)     // 자격 증명 허용
         .exposedHeaders(TokenType.ACCESS.getValue(), HttpHeaders.LOCATION);   // 클라이언트에 노출할 헤더 목록
+  }
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(callUserResolver);
   }
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/annotation/CallUser.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/annotation/CallUser.java
@@ -1,0 +1,11 @@
+package com.service.sport_companion.domain.model.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CallUser {
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
**CallUser**
- Resolver에서 사용할 어노테이션 정의

**CallUserResolver**
- supportsParameter : CallUser 어노테이션이 있는 파라미터를 대상으로 resolver를 수행한다.
- resolveArgument : JwtUtil을 이용하여 request header의 token에서 userId를 가져와서 반환한다.

**WebMvcConfig**
- CallUserResolver를 사용할 resolver로 등록한다.

## 스크린샷
![image](https://github.com/user-attachments/assets/68ca5a86-3572-4b65-a363-db1e3da7779b)

## 주의사항
**사용법** : Controller에서 `@CallUser Long userId`를 통해 해당 API를 요청한 사용자의 id(user_id) 값을 가져올 수 있음 (스크린샷 참고)

Closes #27
