### PR TITLE
[feat] 회원가입 API 구현 및 쿠키값 전달을 위해 Https & Http 전부 허용 설정

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/ClubsHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/ClubsHandler.java
@@ -1,0 +1,17 @@
+package com.service.sport_companion.api.component;
+
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.repository.ClubsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ClubsHandler {
+
+  private final ClubsRepository clubsRepository;
+
+  public ClubsEntity findByClubName(String clubName) {
+    return clubsRepository.findByClubName(clubName);
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/RedisHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/RedisHandler.java
@@ -1,0 +1,21 @@
+package com.service.sport_companion.api.component;
+
+import com.service.sport_companion.core.exception.GlobalException;
+import com.service.sport_companion.domain.entity.SignUpDataEntity;
+import com.service.sport_companion.domain.model.type.FailedResultType;
+import com.service.sport_companion.domain.repository.SignUpDataRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisHandler {
+
+  private final SignUpDataRepository signUpDataRepository;
+
+  public SignUpDataEntity getSignUpDataByProviderId(String providerId) {
+    return signUpDataRepository.findById(providerId)
+        .orElseThrow(() -> new GlobalException(FailedResultType.PROVIDER_ID_NOT_FOUND));
+  }
+
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/SupportedClubsHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/SupportedClubsHandler.java
@@ -1,0 +1,17 @@
+package com.service.sport_companion.api.component;
+
+import com.service.sport_companion.domain.entity.SupportedClubsEntity;
+import com.service.sport_companion.domain.repository.SupportedClubsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SupportedClubsHandler {
+
+  private final SupportedClubsRepository supportedClubsRepository;
+
+  public void saveSupportedClub(SupportedClubsEntity supportedClub) {
+    supportedClubsRepository.save(supportedClub);
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/UserHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/UserHandler.java
@@ -78,4 +78,11 @@ public class UserHandler {
         .provider(userInfo.getProvider())
         .build());
   }
+
+  /**
+   * 사용자 정보 저장
+   */
+  public void saveUser(UsersEntity user) {
+    usersRepository.save(user);
+  }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/AuthController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/AuthController.java
@@ -1,8 +1,11 @@
 package com.service.sport_companion.api.controller;
 
 import com.service.sport_companion.api.service.AuthService;
+import com.service.sport_companion.domain.model.dto.request.auth.SignUpDto;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +15,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,10 +30,11 @@ public class AuthController {
   private final AuthService authService;
 
   @GetMapping("/kakao")
-  public ResponseEntity<Void> oAuthForKakao(@RequestParam String code, HttpServletResponse response) {
+  public ResponseEntity<Void> oAuthForKakao(@RequestParam String code,
+      HttpServletRequest request, HttpServletResponse response) {
 
     log.info("Kakao code {}", code);
-    String redirectUrl = authService.oAuthForKakao(code, response);
+    String redirectUrl = authService.oAuthForKakao(code, request, response);
 
     log.info("Kakao redirect {}", redirectUrl);
     HttpHeaders headers = new HttpHeaders();
@@ -42,5 +48,12 @@ public class AuthController {
     @NotBlank(message = "닉네임을 입력해 주세요.") @PathVariable("nickname") String nickname) {
 
     return ResponseEntity.ok(authService.checkNickname(nickname));
+  }
+
+  @PostMapping("/signup")
+  public ResponseEntity<ResultResponse> signup(@RequestBody @Valid SignUpDto signUpDto) {
+
+    ResultResponse response = authService.signup(signUpDto);
+    return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
@@ -1,13 +1,18 @@
 package com.service.sport_companion.api.service;
 
+import com.service.sport_companion.domain.model.dto.request.auth.SignUpDto;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
 
   // 카카오 회원가입 or 로그인
-  String oAuthForKakao(String code, HttpServletResponse response);
+  String oAuthForKakao(String code, HttpServletRequest request, HttpServletResponse response);
 
   // 닉네임 중복 확인
   ResultResponse checkNickname(String nickname);
+
+  // 회원가입 추가 데이터 저장
+  ResultResponse signup(SignUpDto signUpDto);
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
@@ -20,7 +20,6 @@ import com.service.sport_companion.domain.model.type.SuccessResultType;
 import com.service.sport_companion.domain.model.type.TokenType;
 import com.service.sport_companion.domain.model.type.UrlType;
 import com.service.sport_companion.domain.model.type.UserRole;
-import com.service.sport_companion.domain.repository.SupportedClubsRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
@@ -4,15 +4,26 @@ import static com.service.sport_companion.api.utils.HttpCookieUtil.addCookieToRe
 
 import com.service.sport_companion.api.auth.jwt.JwtUtil;
 import com.service.sport_companion.api.auth.oauth.KakaoAuthHandler;
+import com.service.sport_companion.api.component.ClubsHandler;
+import com.service.sport_companion.api.component.RedisHandler;
+import com.service.sport_companion.api.component.SupportedClubsHandler;
 import com.service.sport_companion.api.component.UserHandler;
 import com.service.sport_companion.api.service.AuthService;
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.entity.SignUpDataEntity;
+import com.service.sport_companion.domain.entity.SupportedClubsEntity;
 import com.service.sport_companion.domain.entity.UsersEntity;
 import com.service.sport_companion.domain.model.auth.KakaoUserDetailsDTO;
+import com.service.sport_companion.domain.model.dto.request.auth.SignUpDto;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import com.service.sport_companion.domain.model.type.SuccessResultType;
 import com.service.sport_companion.domain.model.type.TokenType;
 import com.service.sport_companion.domain.model.type.UrlType;
+import com.service.sport_companion.domain.model.type.UserRole;
+import com.service.sport_companion.domain.repository.SupportedClubsRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,13 +35,17 @@ public class AuthServiceImpl implements AuthService {
 
   private final KakaoAuthHandler kakaoAuthHandler;
   private final UserHandler userHandler;
+  private final RedisHandler redisHandler;
+  private final ClubsHandler clubsHandler;
+  private final SupportedClubsHandler supportedClubsHandler;
   private final JwtUtil jwtUtil;
 
   private final long TEN_MINUTES = 10 * 60;
   private final long ONE_DAY = 24 * 60 * 60;
 
   @Override
-  public String oAuthForKakao(String code, HttpServletResponse response) {
+  public String oAuthForKakao(String code,
+      HttpServletRequest request, HttpServletResponse response) {
     // "인가 코드"로 "액세스 토큰" 요청
     String accessToken = kakaoAuthHandler.getAccessToken(code);
 
@@ -42,38 +57,41 @@ public class AuthServiceImpl implements AuthService {
 
     // 가입 이력이 없는 경우 추가 데이터 입력을 위해 리다이렉트
     if(user == null) {
-      return handleSignup(userInfo, response);
+      return handleSignup(userInfo, request, response);
     }
 
     // 로그인 성공 페이지로 리다이렉트
-    return handleLogin(user, response);
+    return handleLogin(user, request, response);
   }
 
   // 회원가입 처리
-  private String handleSignup(KakaoUserDetailsDTO userInfo, HttpServletResponse response) {
+  private String handleSignup(KakaoUserDetailsDTO userInfo,
+      HttpServletRequest request, HttpServletResponse response) {
     String nickname = userHandler.getRandomNickname(1);
 
     String signUpData = jwtUtil.createSignupData(userInfo.getProviderId(), nickname);
 
     // 쿠키 생성 및 응답 헤더 추가
-    addCookieToResponse(response, "signUpData", signUpData, TEN_MINUTES);
+    addCookieToResponse(request, response, "signUpData", signUpData, TEN_MINUTES);
 
     userHandler.saveSingUpCacheData(userInfo);
     return UrlType.SIGNUP_URL.getUrl();
   }
 
   // 로그인 처리
-  private String handleLogin(UsersEntity user, HttpServletResponse response) {
+  private String handleLogin(UsersEntity user,
+      HttpServletRequest request, HttpServletResponse response) {
     String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
     String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
 
     // 쿠키 생성 및 응답 헤더 추가
-    addCookieToResponse(response, TokenType.ACCESS.getValue(), access, TEN_MINUTES);
-    addCookieToResponse(response, TokenType.REFRESH.getValue(), refresh, ONE_DAY);
+    addCookieToResponse(request, response, TokenType.ACCESS.getValue(), access, TEN_MINUTES);
+    addCookieToResponse(request, response, TokenType.REFRESH.getValue(), refresh, ONE_DAY);
 
     return UrlType.FRONT_LOCAL_URL.getUrl();
   }
 
+  // 닉네임 중복 검증
   @Override
   public ResultResponse checkNickname(String nickname) {
     boolean isValidNickname = !userHandler.existsByNickname(nickname);
@@ -82,5 +100,43 @@ public class AuthServiceImpl implements AuthService {
       SuccessResultType.AVAILABLE_NICKNAME : SuccessResultType.UNAVAILABLE_NICKNAME;
 
     return new ResultResponse(resultType, isValidNickname);
+  }
+
+  // 회원가입
+  @Override
+  public ResultResponse signup(SignUpDto signUpDto) {
+    // 1. Redis에서 사용자 데이터 가져오기
+    SignUpDataEntity signUpData = redisHandler.getSignUpDataByProviderId(signUpDto.getProviderId());
+
+    // 2. 사용자 생성 및 저장
+    UsersEntity user = createUser(signUpData, signUpDto.getNickname());
+    userHandler.saveUser(user);
+
+    // 3. 선호 구단 처리
+    saveSupportedClub(user, signUpDto.getClubName());
+
+    return ResultResponse.of(SuccessResultType.SUCCESS_SIGNUP);
+  }
+
+  private UsersEntity createUser(SignUpDataEntity signUpData, String nickname) {
+    return UsersEntity.builder()
+        .email(signUpData.getEmail())
+        .nickname(nickname)
+        .provider(signUpData.getProvider())
+        .providerId(signUpData.getProviderId())
+        .role(UserRole.USER)
+        .createdAt(LocalDateTime.now())
+        .build();
+  }
+
+  private void saveSupportedClub(UsersEntity user, String clubName) {
+    ClubsEntity club = clubsHandler.findByClubName(clubName);
+
+    SupportedClubsEntity supportedClub = SupportedClubsEntity.builder()
+        .user(user)
+        .club(club)
+        .build();
+
+    supportedClubsHandler.saveSupportedClub(supportedClub);
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/utils/HttpCookieUtil.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/utils/HttpCookieUtil.java
@@ -4,15 +4,24 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 
+
+@Slf4j
 public class HttpCookieUtil {
 
-  public static void addCookieToResponse(HttpServletResponse response, String key, String value, long maxAge) {
+  public static void addCookieToResponse(
+      HttpServletRequest request, HttpServletResponse response,
+      String key, String value, long maxAge) {
+
+    boolean isSecure = request.isSecure();
+
+    log.info("isSecure: {}", isSecure);
     String cookie =  ResponseCookie.from(key, value)
         .httpOnly(true)         // HttpOnly 설정
-        .secure(true)           // Secure 설정 (HTTPS 환경 필수)
+        .secure(isSecure)       // Secure 설정 (HTTP or HTTPS)
         .path("/")              // 쿠키 경로 설정
         .maxAge(maxAge)         // 유효 시간 (초 단위)
         .sameSite("None")       // SameSite 설정 (Cross-Origin 허용)

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/ClubsHandlerTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/ClubsHandlerTest.java
@@ -1,0 +1,57 @@
+package com.service.sport_companion.api.component;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.entity.ReservationSiteEntity;
+import com.service.sport_companion.domain.entity.SportsEntity;
+import com.service.sport_companion.domain.repository.ClubsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClubsHandlerTest {
+
+  @Mock
+  private ClubsRepository clubsRepository;
+
+  @InjectMocks
+  private ClubsHandler clubsHandler;
+
+  private final String CLUB_NAME = "KIA 타이거즈";
+
+  private ClubsEntity club;
+
+  @BeforeEach
+  void setUp() {
+    club = ClubsEntity.builder()
+        .clubId(1L)
+        .clubName("KIA 타이거즈")
+        .clubStadium("광주 기아 챔피언스 필드")
+        .sports(SportsEntity.builder().sportId(1L).build())
+        .emblemImg("imageUrl1")
+        .introduction(null)
+        .reservationSite(ReservationSiteEntity.builder().reservationSiteId(1L).build())
+        .build();
+  }
+
+  @Test
+  @DisplayName("findByClubName : 구단 정보 반환 성공")
+  void shouldReturnClubs() {
+    // given
+    when(clubsRepository.findByClubName(CLUB_NAME)).thenReturn(club);
+
+    // when
+    ClubsEntity response = clubsHandler.findByClubName(CLUB_NAME);
+
+    // then
+    assertEquals(response, club);
+  }
+
+}

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/RedisHandlerTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/RedisHandlerTest.java
@@ -1,0 +1,67 @@
+package com.service.sport_companion.api.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.service.sport_companion.core.exception.GlobalException;
+import com.service.sport_companion.domain.entity.SignUpDataEntity;
+import com.service.sport_companion.domain.repository.SignUpDataRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RedisHandlerTest {
+
+  @Mock
+  private SignUpDataRepository signUpDataRepository;
+
+  @InjectMocks
+  private RedisHandler redisHandler;
+
+  private final String PROVIDER_ID = "providerId";
+  private final String PROVIDER = "kakao";
+  private final String EMAIL = "example@example.com";
+
+  private SignUpDataEntity signUpData;
+
+  @BeforeEach
+  void setUp() {
+    signUpData = SignUpDataEntity.builder()
+        .providerId(PROVIDER_ID)
+        .provider(PROVIDER)
+        .email(EMAIL)
+        .build();
+  }
+
+  @Test
+  @DisplayName("getSignUpDataByProviderId : 캐시 데이터 조회 성공")
+  void shouldReturnSignUpData() {
+    // given
+    when(signUpDataRepository.findById(PROVIDER_ID)).thenReturn(Optional.of(signUpData));
+
+    // when
+    SignUpDataEntity response = redisHandler.getSignUpDataByProviderId(PROVIDER_ID);
+
+    // then
+    assertEquals(response.getProviderId(), signUpData.getProviderId());
+    assertEquals(response.getProvider(), signUpData.getProvider());
+    assertEquals(response.getEmail(), signUpData.getEmail());
+  }
+
+  @Test
+  @DisplayName("getSignUpDataByProviderId : 캐시 데이터 조회 실패")
+  void shouldReturnExceptionProviderNotFound() {
+    // given
+    when(signUpDataRepository.findById(PROVIDER_ID)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThrows(GlobalException.class, () -> redisHandler.getSignUpDataByProviderId(PROVIDER_ID));
+  }
+}

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/SupportedClubsHandlerTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/SupportedClubsHandlerTest.java
@@ -1,0 +1,77 @@
+package com.service.sport_companion.api.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.entity.ReservationSiteEntity;
+import com.service.sport_companion.domain.entity.SportsEntity;
+import com.service.sport_companion.domain.entity.SupportedClubsEntity;
+import com.service.sport_companion.domain.entity.UsersEntity;
+import com.service.sport_companion.domain.model.type.UserRole;
+import com.service.sport_companion.domain.repository.SupportedClubsRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SupportedClubsHandlerTest {
+
+  @Mock
+  private SupportedClubsRepository supportedClubsRepository;
+
+  private static final String EMAIL = "test@email.com";
+  private static final String NICKNAME = "nickname";
+  private static final String KAKAO_PROVIDER = "kakao";
+  private static final String KAKAO_PROVIDER_ID = "kakao_provider_id";
+
+  private UsersEntity user;
+  private ClubsEntity club;
+  private SupportedClubsEntity supportedClub;
+
+  @BeforeEach
+  void setUp() {
+    user = UsersEntity.builder()
+        .userId(1L)
+        .email(EMAIL)
+        .nickname(NICKNAME)
+        .provider(KAKAO_PROVIDER)
+        .providerId(KAKAO_PROVIDER_ID)
+        .role(UserRole.USER)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    club = ClubsEntity.builder()
+        .clubId(1L)
+        .clubName("KIA 타이거즈")
+        .clubStadium("광주 기아 챔피언스 필드")
+        .sports(SportsEntity.builder().sportId(1L).build())
+        .emblemImg("imageUrl1")
+        .introduction(null)
+        .reservationSite(ReservationSiteEntity.builder().reservationSiteId(1L).build())
+        .build();
+
+    supportedClub = SupportedClubsEntity.builder()
+        .user(user)
+        .club(club)
+        .build();
+  }
+
+  @Test
+  @DisplayName("선호 구단 저장 성공")
+  void saveSupportedClubSuccessfully() {
+    // given
+    when(supportedClubsRepository.save(supportedClub)).thenReturn(supportedClub);
+
+    // when
+    SupportedClubsEntity response = supportedClubsRepository.save(supportedClub);
+
+    // then
+    assertEquals(response, supportedClub);
+  }
+
+}

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/UserHandlerTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/UserHandlerTest.java
@@ -196,4 +196,17 @@ class UserHandlerTest {
     // then
     assertEquals(response, signUpDataEntity);
   }
+
+  @Test
+  @DisplayName("회원 정보 저장 성공")
+  void saveUserSuccessfully() {
+    // given
+    when(usersRepository.save(user)).thenReturn(user);
+
+    // when
+    UsersEntity response = usersRepository.save(user);
+
+    // then
+    assertEquals(response, user);
+  }
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/request/auth/SignUpDto.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/request/auth/SignUpDto.java
@@ -1,0 +1,14 @@
+package com.service.sport_companion.domain.model.dto.request.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignUpDto {
+
+  private String providerId;
+  private String nickname;
+  private String clubName;
+
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
@@ -11,6 +11,8 @@ public enum FailedResultType {
   // Auth
   EMAIL_ALREADY_USED(HttpStatus.BAD_REQUEST, "가입 이력이 있는 이메일 입니다."),
   USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 회원 입니다."),
+  PROVIDER_ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 ProviderId로 회원을 찾을 수 없습니다."),
+
 
   // API
   UNIQUE_NICKNAME_FAILED(HttpStatus.TOO_MANY_REQUESTS, "닉네임 생성에 실패했습니다."),

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/ClubsRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/ClubsRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ClubsRepository extends JpaRepository<ClubsEntity, Long> {
 
+  ClubsEntity findByClubName(String clubName);
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 회원가입을 위해 사용자가 입력한 추가 데이터 저장 API 구현
- HTTP & HTTPS 요청 모두 쿠키 값을 전달 할 수 있도록 메서드 수정

주요 클래스
#### Module-Api
- AuthController
   - signup : 회원가입 추가 데이터 저장하기 위한 API 구현
   - oAuthForKakao :  HTTPS or HTTP 요청을 구분하기 위해 HttpServletRequest 추가

- AuthService & AuthServiceImpl
   - 회원가입 추가 데이터 저장을 위한 비즈니스 로직 구현
       - 사용자 정보 저장
       - 선호 구단 정보 저장
       
- RedisHandler
   - 캐시 데이터 조회를 위한 Handler 클래스 

- ClubsHandler
   - 구단 정보 조회를 위한 Handler 클래스

- SupportedClubsHandler
   - 사용자 별 선호 구단 저장을 위한 Handler 클래스

- HttpCookieUtil
   - HTTP or HTTPS 요청 구분을 위해 boolean isSecure = request.isSecure(); 로직 추가  
    

## 스크린샷

## 주의사항

Closes #13 
