### PR TITLE
[feat] 뉴스 크롤링 배치 작업 추가

### DIFF
--- a/sport_companion/module-batch/build.gradle
+++ b/sport_companion/module-batch/build.gradle
@@ -21,5 +21,8 @@ dependencies {
 
     // jsoup
     implementation 'org.jsoup:jsoup:1.18.1'
+
+    // batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 }
 

--- a/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/component/BatchScheduler.java
+++ b/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/component/BatchScheduler.java
@@ -1,0 +1,27 @@
+package com.service.sport_companion.batch.component;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BatchScheduler {
+
+  private final JobLauncher jobLauncher;
+  private final Job mbcCrawlingJob;
+
+  // 매일 11:50, 23:50 mbcCrawlingJob 수행
+  @Scheduled(cron = "0 50 11,23 * * *")
+  public void scheduleMbcCrawlingJob() throws Exception {
+    JobParameters jobParameters = new JobParametersBuilder()
+      .addString("timestamp", String.valueOf(System.currentTimeMillis()))
+      .toJobParameters();
+
+    jobLauncher.run(mbcCrawlingJob, jobParameters);
+  }
+}

--- a/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/component/WebDriverHandler.java
+++ b/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/component/WebDriverHandler.java
@@ -1,0 +1,45 @@
+package com.service.sport_companion.batch.component;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WebDriverHandler {
+
+  @Value("${web.driver.id}")
+  private String WEB_DRIVER_ID;
+
+  @Value("${web.driver.path}")
+  private String WEB_DRIVER_PATH;
+
+  public ChromeOptions chromeOptions() {
+    // 크롬 드라이버 경로 설정
+    System.setProperty(WEB_DRIVER_ID, WEB_DRIVER_PATH);
+
+    // 크롬 옵션 설정
+    ChromeOptions options = new ChromeOptions();
+    options.addArguments("--headless"); // 헤드리스 모드 활성화
+
+    return options;
+  }
+
+  // url로 WebDriver 생성해서 리턴
+  public WebDriver getWebDriver(String url) {
+    WebDriver driver = new ChromeDriver(chromeOptions());
+    driver.get(url);
+
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    wait.until(
+      d -> ((JavascriptExecutor) d).executeScript("return jQuery.active == 0"));
+
+    return driver;
+  }
+}

--- a/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/config/BatchConfig.java
+++ b/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/config/BatchConfig.java
@@ -1,0 +1,43 @@
+package com.service.sport_companion.batch.config;
+
+import com.service.sport_companion.batch.news.MbcNewsCrawling;
+import com.service.sport_companion.batch.news.NewsItemWriter;
+import com.service.sport_companion.domain.entity.NewsEntity;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.JpaTransactionManager;
+
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class BatchConfig {
+
+  private final EntityManagerFactory entityManagerFactory;
+  private final MbcNewsCrawling mbcNewsCrawling;
+  private final NewsItemWriter newsItemWriter;
+
+  @Bean
+  public Job mbcCrawlingJob(JobRepository jobRepository, Step mbcCrawlingStep) {
+    return new JobBuilder("mbcCrawlingJob", jobRepository)
+      .start(mbcCrawlingStep)
+      .build();
+  }
+
+  @Bean
+  public Step mbcCrawlingStep(JobRepository jobRepository) {
+    return new StepBuilder("mbcCrawlingStep", jobRepository)
+      .<NewsEntity, NewsEntity>chunk(100, new JpaTransactionManager(entityManagerFactory))
+      .reader(new ListItemReader<>(mbcNewsCrawling.crawlingMain()))
+      .writer(newsItemWriter)
+      .build();
+  }
+}

--- a/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/news/MbcNewsCrawling.java
+++ b/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/news/MbcNewsCrawling.java
@@ -1,0 +1,76 @@
+package com.service.sport_companion.batch.news;
+
+import com.service.sport_companion.batch.component.WebDriverHandler;
+import com.service.sport_companion.core.exception.GlobalException;
+import com.service.sport_companion.domain.entity.NewsEntity;
+import com.service.sport_companion.domain.model.type.FailedResultType;
+import com.service.sport_companion.domain.model.type.NewsType;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.openqa.selenium.WebDriver;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MbcNewsCrawling {
+
+  private final WebDriverHandler webDriverHandler;
+
+  // 배치로 실행시킬 MBC News 크롤링 메인 작업
+  @Transactional
+  public List<NewsEntity> crawlingMain() {
+    String url = "https://imnews.imbc.com/news/2024/sports/";
+    WebDriver driver = webDriverHandler.getWebDriver(url);
+
+    try {
+      return parsing(driver.getPageSource());
+    } finally {
+      driver.quit();
+    }
+  }
+
+  // pageSource에서 파싱하여 필요한 뉴스 데이터 가져오기
+  public List<NewsEntity> parsing(String pageSource) {
+    Document doc = Jsoup.parse(pageSource);
+    Elements listArea = doc.getElementsByClass("list_area");
+    // 가장 오래된 데이터부터 가져오기 위해 List reverse
+    Collections.reverse(listArea);
+
+    List<NewsEntity> newsItemList = new ArrayList<>();
+    for (Element list : listArea) {
+      Elements items = list.select("ul > li");
+      Collections.reverse(items);
+
+      for (Element item : items) {
+        String newsLink = item.select("a").attr("href");
+        String thumbnail = item.select("a > .img > img").attr("src");
+        String headline = item.select("a > .txt_w > .tit").text();
+        NewsType newsType = (item.select("a > .img").hasClass("ico_vod")) ?
+          NewsType.VIDEO : NewsType.TEXT;
+
+        if (newsLink.isEmpty() || thumbnail.isEmpty() || headline.isEmpty()) {
+          throw new GlobalException(FailedResultType.MBC_NEWS_PARSING_FAILED);
+        }
+
+        newsItemList.add(NewsEntity.builder()
+          .newsLink(newsLink)
+          .thumbnail(thumbnail)
+          .headline(headline)
+          .newsType(newsType)
+          .newsDate(LocalDate.now())
+          .build());
+      }
+    }
+    return newsItemList;
+  }
+}

--- a/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/news/NewsItemWriter.java
+++ b/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/news/NewsItemWriter.java
@@ -1,0 +1,24 @@
+package com.service.sport_companion.batch.news;
+
+import com.service.sport_companion.domain.entity.NewsEntity;
+import com.service.sport_companion.domain.repository.NewsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class NewsItemWriter implements ItemWriter<NewsEntity> {
+
+  private final NewsRepository newsRepository;
+
+  @Override
+  public void write(Chunk<? extends NewsEntity> chunk) {
+    for (NewsEntity newsEntity : chunk) {
+      if (!newsRepository.existsByNewsLink(newsEntity.getNewsLink())) {
+        newsRepository.save(newsEntity);
+      }
+    }
+  }
+}

--- a/sport_companion/module-batch/src/main/resources/application-dev.yml
+++ b/sport_companion/module-batch/src/main/resources/application-dev.yml
@@ -18,3 +18,8 @@ spring:
     url: ${DEV.DATABASE.URL}
     username: ${DEV.DATABASE.USERNAME}
     password: ${DEV.DATABASE.PASSWORD}
+
+web:
+  driver:
+    id: webdriver.chrome.driver
+    path: C:\Program Files\chromedriver-win64\chromedriver.exe

--- a/sport_companion/module-batch/src/main/resources/application-dev.yml
+++ b/sport_companion/module-batch/src/main/resources/application-dev.yml
@@ -1,6 +1,13 @@
 spring:
   config:
     import: classpath:secret.yml
+
+  data:
+    redis:
+      port: ${DEV.REDIS.PORT}
+      host: ${DEV.REDIS.HOST}
+      timeout: ${DEV.REDIS.TIMEOUT}
+
   jpa:
     hibernate:
       # 필요에 따라서 수정 필요

--- a/sport_companion/module-batch/src/main/resources/application-dev.yml
+++ b/sport_companion/module-batch/src/main/resources/application-dev.yml
@@ -1,0 +1,20 @@
+spring:
+  config:
+    import: classpath:secret.yml
+  jpa:
+    hibernate:
+      # 필요에 따라서 수정 필요
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        check_nullability: true
+        format-sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+        default_batch_fetch_size: 1000
+    open-in-view: false
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DEV.DATABASE.URL}
+    username: ${DEV.DATABASE.USERNAME}
+    password: ${DEV.DATABASE.PASSWORD}

--- a/sport_companion/module-batch/src/main/resources/application.yml
+++ b/sport_companion/module-batch/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  profiles:
+    active:
+      - ${ACTIVE_PROFILE:dev}

--- a/sport_companion/module-batch/src/test/java/com/service/sport_companion/batch/news/MbcNewsCrawlingTest.java
+++ b/sport_companion/module-batch/src/test/java/com/service/sport_companion/batch/news/MbcNewsCrawlingTest.java
@@ -1,0 +1,55 @@
+package com.service.sport_companion.batch.news;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.service.sport_companion.domain.entity.NewsEntity;
+import com.service.sport_companion.domain.model.type.NewsType;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MbcNewsCrawlingTest {
+
+  @InjectMocks
+  private MbcNewsCrawling mbcNewsCrawling;
+
+  @Test
+  @DisplayName("parsing : html에서 정확히 파싱하는지 테스트")
+  void parsingSuccess() {
+    // given
+    String html = """
+            <body>
+              <div class="list_area">
+                <ul>
+                  <li>
+                    <a href="href_url">
+                      <span class="img ico_vod">
+                        <img src="img_url">
+                      </span>
+                      <span class="txt_w">
+                        <span class="tit">headline</span>
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </body>
+      """;
+
+    // when
+    List<NewsEntity> result = mbcNewsCrawling.parsing(html);
+
+    // then
+    assertEquals(result.size(), 1);
+    assertEquals(result.get(0).getHeadline(), "headline");
+    assertEquals(result.get(0).getThumbnail(), "img_url");
+    assertEquals(result.get(0).getNewsLink(), "href_url");
+    assertEquals(result.get(0).getNewsDate(), LocalDate.now());
+    assertEquals(result.get(0).getNewsType(), NewsType.VIDEO);
+  }
+}

--- a/sport_companion/module-batch/src/test/java/com/service/sport_companion/batch/news/MbcNewsCrawlingTest.java
+++ b/sport_companion/module-batch/src/test/java/com/service/sport_companion/batch/news/MbcNewsCrawlingTest.java
@@ -24,7 +24,7 @@ class MbcNewsCrawlingTest {
     // given
     String html = """
             <body>
-              <div class="list_area">
+              <div class="result_list">
                 <ul>
                   <li>
                     <a href="href_url">
@@ -33,6 +33,8 @@ class MbcNewsCrawlingTest {
                       </span>
                       <span class="txt_w">
                         <span class="tit">headline</span>
+                        <span class="sub"><span class="date">""" + LocalDate.now() + """
+                      </span></span>
                       </span>
                     </a>
                   </li>

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/NewsEntity.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/NewsEntity.java
@@ -1,31 +1,45 @@
 package com.service.sport_companion.domain.entity;
 
+import com.service.sport_companion.domain.model.type.NewsType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity(name = "News")
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 public class NewsEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long newsId;
 
-  private LocalDateTime dateTime;
+  private LocalDate newsDate;
 
   private String newsLink;
 
   private String thumbnail;
 
-  private String headLine;
+  private String headline;
+
+  @Enumerated(value = EnumType.STRING)
+  private NewsType newsType;
+
+  @CreatedDate
+  private LocalDateTime createdAt;
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
@@ -17,6 +17,9 @@ public enum FailedResultType {
   UNIQUE_NICKNAME_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "닉네임 생성 중 문제가 발생했습니다."),
   ACCESS_TOKEN_RETRIEVAL(HttpStatus.UNAUTHORIZED, "액세스 토큰을 가져오는 데 실패했습니다."),
   USER_INFO_RETRIEVAL(HttpStatus.UNAUTHORIZED, "사용자 정보를 가져오는 데 실패했습니다."),
+
+  // Crawling
+  MBC_NEWS_PARSING_FAILED(HttpStatus.BAD_GATEWAY, "MBC 뉴스 파싱에 실패했습니다.")
   ;
 
   private final HttpStatus status;

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/NewsType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/NewsType.java
@@ -1,0 +1,6 @@
+package com.service.sport_companion.domain.model.type;
+
+public enum NewsType {
+  TEXT,
+  VIDEO
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/NewsRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/NewsRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface NewsRepository extends JpaRepository<NewsEntity, Long> {
 
+  boolean existsByNewsLink(String newsLink);
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
**batch/build.gradle**
- spring batch 의존성 추가

**batch/application.yml, application-dev.yml**
- batch 모듈에서 DB를 사용할 수 있도록 연결 정보 설정
- 크롬 web driver id와 경로 값 설정

**NewsEntity**
- 뉴스 작성일시에서 시간은 제외 (LocalDateTime -> LocalDate)
- headLine -> headline 컬럼명 수정
- newsType : 가져온 뉴스가 '기사'인지 '영상'인지 구분하는 컬럼 추가
- createdAt : 최신순 정렬을 위한 수집 날짜 추가

**NewsRepository**
- existsByNewsLink : 중복 저장을 막기 위해 뉴스 링크를 기준으로 테이블에 존재하는지 확인하는 메서드 추가

**WebDriverHandler**
- WebDriver 관련 설정 및 생성을 담당하는 클래스 구현

**BatchConfig**
- 배치 작업(크롤링)을 수행하는 Job과 Step 빈을 등록하는 클래스 구현

**MbcNewsCrawling**
- 스포츠 뉴스를 크롤링하여 헤드라인, 썸네일, 뉴스 링크를 파싱하는 기능 구현
- Step에서 Reader의 역할을 함

**NewsItemWriter**
- ItemWriter의 구현체로 읽어온 데이터를 뉴스 Entity에 저장하는 기능 구현

**BatchScheduler**
- BatchConfig에서 등록한 Job을 매일 11:50, 23:50에 실행할 수 있도록 스케줄링 등록
- 0시가 되면 아직 아무것도 올라오지 않은 다음날 데이터를 조회하므로 50분으로 설정


## 스크린샷
![image](https://github.com/user-attachments/assets/1f02e47c-14a9-43a7-90cf-1a643ba7b8d2)

## 주의사항
- Extenral Libraries **>** Gradle: org.springframework.batch:spring-batch-core **>** schema-mysql.sql을 실행하여 배치 관련 테이블 생성 필요
- 크롬 드라이버 설치 및 application-dev에서 경로 설정 필요
  - 참고) https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json

Closes #28
