### PR TITLE
[feat] Jwt Access 토큰 재발급 API 구현

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/AuthController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/AuthController.java
@@ -56,4 +56,12 @@ public class AuthController {
     ResultResponse response = authService.signup(signUpDto);
     return new ResponseEntity<>(response, response.getStatus());
   }
+
+  @GetMapping("/reissue-token")
+  public ResponseEntity<ResultResponse> reissueToken(
+      HttpServletRequest request, HttpServletResponse response) {
+
+    ResultResponse resultResponse = authService.reissueToken(request, response);
+    return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
+  }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
@@ -15,4 +15,7 @@ public interface AuthService {
 
   // 회원가입 추가 데이터 저장
   ResultResponse signup(SignUpDto signUpDto);
+
+  // Jwt 토큰 재발급 로직
+  ResultResponse reissueToken(HttpServletRequest request, HttpServletResponse response);
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
@@ -173,7 +173,7 @@ public class AuthServiceImpl implements AuthService {
     UsersEntity user = userHandler.findByUserId(userId);
 
     String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
-    addCookieToResponse(request, response, TokenType.ACCESS.getValue(), access, TEN_MINUTES);
+    response.addHeader(TokenType.ACCESS.getValue(), access);
 
     return ResultResponse.of(SuccessResultType.SUCCESS_REISSUE_TOKEN);
   }

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/AuthServiceImplTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/AuthServiceImplTest.java
@@ -303,8 +303,7 @@ class AuthServiceImplTest {
 
     // then
     assertEquals(SuccessResultType.SUCCESS_REISSUE_TOKEN.getStatus(), resultResponse.getStatus());
-    verify(response).addHeader(eq(HttpHeaders.SET_COOKIE),
-        argThat(cookie -> cookie.contains(TokenType.ACCESS.getValue() + "=" + NEW_ACCESS_TOKEN)));
+    verify(response).addHeader(TokenType.ACCESS.getValue(), NEW_ACCESS_TOKEN);
   }
 
   // 실패 케이스: 쿠키 값이 null인 경우

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/AuthServiceImplTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/AuthServiceImplTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -23,8 +25,10 @@ import com.service.sport_companion.domain.model.dto.request.auth.SignUpDto;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import com.service.sport_companion.domain.model.type.FailedResultType;
 import com.service.sport_companion.domain.model.type.SuccessResultType;
+import com.service.sport_companion.domain.model.type.TokenType;
 import com.service.sport_companion.domain.model.type.UrlType;
 import com.service.sport_companion.domain.model.type.UserRole;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
@@ -37,6 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceImplTest {
@@ -68,12 +73,15 @@ class AuthServiceImplTest {
   @InjectMocks
   private AuthServiceImpl authServiceImpl;
 
+  private static final long USERID = 1L;
   private static final String EMAIL = "test@email.com";
   private static final String NICKNAME = "nickname";
   private static final String CODE = "kakaoCode";
   private static final String KAKAO_TOKEN = "kakao-token";
   private static final String KAKAO_PROVIDER = "kakao";
   private static final String KAKAO_PROVIDER_ID = "kakao_provider_id";
+  private static final String REFRESH_TOKEN = "refresh_token";
+  private static final String NEW_ACCESS_TOKEN = "access_token";
 
 
   private KakaoUserDetailsDTO kakaoUserDetails;
@@ -98,7 +106,7 @@ class AuthServiceImplTest {
     kakaoUserDetails = new KakaoUserDetailsDTO(attributes);
 
     user = UsersEntity.builder()
-        .userId(1L)
+        .userId(USERID)
         .email(EMAIL)
         .nickname(NICKNAME)
         .provider(KAKAO_PROVIDER)
@@ -277,5 +285,48 @@ class AuthServiceImplTest {
 
     // when & then
     assertThrows(GlobalException.class, () -> authServiceImpl.signup(signUpDto));
+  }
+
+  @Test
+  @DisplayName("Access-Token 재발급 성공")
+  void success_Reissue_RefreshToken() {
+    // given
+    Cookie mockCookie = new Cookie(TokenType.REFRESH.getValue(), REFRESH_TOKEN);
+    when(request.getCookies()).thenReturn(new Cookie[] { mockCookie });
+    when(jwtUtil.isExpired(REFRESH_TOKEN)).thenReturn(false);
+    when(jwtUtil.getUserId(REFRESH_TOKEN)).thenReturn(USERID);
+    when(userHandler.findByUserId(USERID)).thenReturn(user);
+    when(jwtUtil.createJwt("access", user.getUserId(), user.getRole())).thenReturn(NEW_ACCESS_TOKEN);
+
+    // when
+    ResultResponse resultResponse = authServiceImpl.reissueToken(request, response);
+
+    // then
+    assertEquals(SuccessResultType.SUCCESS_REISSUE_TOKEN.getStatus(), resultResponse.getStatus());
+    verify(response).addHeader(eq(HttpHeaders.SET_COOKIE),
+        argThat(cookie -> cookie.contains(TokenType.ACCESS.getValue() + "=" + NEW_ACCESS_TOKEN)));
+  }
+
+  // 실패 케이스: 쿠키 값이 null인 경우
+  @Test
+  @DisplayName("Access-Token 재발급 실패 : 쿠키값이 null인 경우")
+  void reissue_RefreshToken_CookieIsNull() {
+    // given
+    when(request.getCookies()).thenReturn(null);
+
+    // when & then
+    assertThrows(GlobalException.class, () -> authServiceImpl.reissueToken(request, response));
+  }
+
+  @Test
+  @DisplayName("Access-Token 재발급 실패 : refresh 토큰이 만료가 된경우")
+  void reissue_RefreshToken_Expired() {
+    // given
+    Cookie mockCookie = new Cookie(TokenType.REFRESH.getValue(), REFRESH_TOKEN);
+    when(request.getCookies()).thenReturn(new Cookie[] { mockCookie });
+    when(jwtUtil.isExpired(REFRESH_TOKEN)).thenReturn(true);
+
+    // when & then
+    assertThrows(GlobalException.class, () -> authServiceImpl.reissueToken(request, response));
   }
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
@@ -12,6 +12,8 @@ public enum FailedResultType {
   EMAIL_ALREADY_USED(HttpStatus.BAD_REQUEST, "가입 이력이 있는 이메일 입니다."),
   USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않은 회원 입니다."),
   PROVIDER_ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 ProviderId로 회원을 찾을 수 없습니다."),
+  COOKIE_IS_NULL(HttpStatus.FORBIDDEN, "쿠키 값이 존재하지 않습니다."),
+  REFRESH_TOKEN_IS_EXPIRED(HttpStatus.UNAUTHORIZED, "Refresh 토큰이 만료되었습니다!"),
 
 
   // API

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -13,6 +13,7 @@ public enum SuccessResultType {
   SUCCESS_LOGIN(HttpStatus.OK, "로그인 성공!"),
   AVAILABLE_NICKNAME(HttpStatus.OK, "사용 가능한 닉네임입니다."),
   UNAVAILABLE_NICKNAME(HttpStatus.OK, "이미 사용 중인 닉네임입니다."),
+  SUCCESS_REISSUE_TOKEN(HttpStatus.OK, "Access 토큰 재발급 성공."),
 
   //Club
   SUCCESS_GET_ALL_CLUBS_LIST(HttpStatus.OK, "모든 구단 조회 성공!"),


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 쿠키 값으로 전달 된 Refresh 토큰을 가지고 Access 토큰 재발급 로직 구현

- AuthController
   - 클라이언트 측으로 부터 전달 받은 요청 및 응답을 전달하기 위해 reissueToken() 메서드 구현
- AuthService & AuthServiceImpl
   - Request에서 Cookie 값을 추출하여 해당 쿠키 값의 유무를 조회
   - Cookie 값에서 추출한 Refresh 토큰 유효성 검증
   - Refresh 토큰을 활용하여 Access 토큰 재발급
   - 재발급 받은 Access 토큰을 헤더에 넣어서 전달  

## 스크린샷

## 주의사항

Closes #33 
