### PR TITLE
[fix] 카카오 회원가입 및 로그인 요청 응답 전달 방식 수정

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/AuthController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/AuthController.java
@@ -29,18 +29,12 @@ public class AuthController {
 
   private final AuthService authService;
 
-  @GetMapping("/kakao")
-  public ResponseEntity<Void> oAuthForKakao(@RequestParam String code,
-      HttpServletRequest request, HttpServletResponse response) {
+  @PostMapping("/kakao")
+  public ResponseEntity<ResultResponse> oAuthForKakao(HttpServletResponse response,
+      @RequestBody @Valid String code) {
 
-    log.info("Kakao code {}", code);
-    String redirectUrl = authService.oAuthForKakao(code, request, response);
-
-    log.info("Kakao redirect {}", redirectUrl);
-    HttpHeaders headers = new HttpHeaders();
-    headers.setLocation(URI.create(redirectUrl));
-
-    return ResponseEntity.status(HttpStatus.FOUND).headers(headers).build();
+    ResultResponse resultResponse = authService.oAuthForKakao(code, response);
+    return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
   }
 
   @GetMapping("/check-nickname/{nickname}")

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
@@ -8,7 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 public interface AuthService {
 
   // 카카오 회원가입 or 로그인
-  String oAuthForKakao(String code, HttpServletRequest request, HttpServletResponse response);
+  ResultResponse oAuthForKakao(String code, HttpServletResponse response);
 
   // 닉네임 중복 확인
   ResultResponse checkNickname(String nickname);

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/auth/SignUpData.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/auth/SignUpData.java
@@ -1,0 +1,13 @@
+package com.service.sport_companion.domain.model.dto.response.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignUpData {
+
+  private String providerId;
+  private String nickname;
+
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum SuccessResultType {
 
   // Auth
+  SUCCESS_SIGNUP_REQUIRED(HttpStatus.OK, "회원가입이 필요한 회원입니다."),
   SUCCESS_SIGNUP(HttpStatus.CREATED, "회원가입 성공!"),
   SUCCESS_LOGIN(HttpStatus.OK, "로그인 성공!"),
   AVAILABLE_NICKNAME(HttpStatus.OK, "사용 가능한 닉네임입니다."),


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 기존 구현 방식
   - 카카오 로그인 요청시 Redirect URL을 백엔드 엔드 포인트로 설정
   - 요청의 결과 값을 쿠키에 저장 후 프론트 URL로 Redirect
- 발생한 문제
   - 요청 결과 전달 시 쿠키 값이 전달이 되지 않음.
- 수정 내용
   - AuthController
      -  /api/v1/auth/kakao 요청 메서드를 GET -> POST로 변경
      - RequestParam으로 전달 받던 code 값을 RequestBody로 전달 받도록 수정
      - 프론트 측으로 요청한 경로로 Redirect를 시키지 않고, ResultResponse 객체를 전달
   - AuthService & AuthServiceImpl
      - 추가로 회원가입이 필요한 경우
          - 쿠키로 전달 하던 providerId & nickname 값을 body에 담아서 전달
      - 로그인 성공인 경우
          - 쿠키로 전달하던 access 토큰 및 refresh 토큰을 response의 header에 담아서 전달    

## 스크린샷

## 주의사항

Closes #36 
