### PR TITLE
[fix] 모든 구단 조회시 전달 데이터 수정

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/ClubsHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/ClubsHandler.java
@@ -1,7 +1,9 @@
 package com.service.sport_companion.api.component;
 
 import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.model.dto.response.clubs.Clubs;
 import com.service.sport_companion.domain.repository.ClubsRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,5 +15,11 @@ public class ClubsHandler {
 
   public ClubsEntity findByClubName(String clubName) {
     return clubsRepository.findByClubName(clubName);
+  }
+
+  public List<Clubs> getAllClubList() {
+    return clubsRepository.findAll().stream()
+        .map(clubsEntity -> new Clubs(clubsEntity.getClubId(), clubsEntity.getClubName()))
+        .toList();
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
             .anyRequest().authenticated());
 
     http
-        .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+        .addFilterAfter(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
     http
         .sessionManagement(session -> session

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/ClubsServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/ClubsServiceImpl.java
@@ -1,10 +1,10 @@
 package com.service.sport_companion.api.service.impl;
 
+import com.service.sport_companion.api.component.ClubsHandler;
 import com.service.sport_companion.api.service.ClubsService;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import com.service.sport_companion.domain.model.dto.response.clubs.Clubs;
 import com.service.sport_companion.domain.model.type.SuccessResultType;
-import com.service.sport_companion.domain.repository.ClubsRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,15 +15,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ClubsServiceImpl implements ClubsService {
 
-  private final ClubsRepository clubsRepository;
+  private final ClubsHandler clubsHandler;
 
   // 모든 구단 조회
   @Override
   public ResultResponse getAllClubList() {
     // 다른 종목 추가시 수정할 예정
-    List<Clubs> clubList = clubsRepository.findAll().stream()
-        .map(clubsEntity -> new Clubs(clubsEntity.getClubName(), clubsEntity.getEmblemImg()))
-        .toList();
+    List<Clubs> clubList = clubsHandler.getAllClubList();
 
     return new ResultResponse(SuccessResultType.SUCCESS_GET_ALL_CLUBS_LIST, clubList);
   }

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/ClubsHandlerTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/ClubsHandlerTest.java
@@ -6,7 +6,9 @@ import static org.mockito.Mockito.when;
 import com.service.sport_companion.domain.entity.ClubsEntity;
 import com.service.sport_companion.domain.entity.ReservationSiteEntity;
 import com.service.sport_companion.domain.entity.SportsEntity;
+import com.service.sport_companion.domain.model.dto.response.clubs.Clubs;
 import com.service.sport_companion.domain.repository.ClubsRepository;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,18 +29,45 @@ class ClubsHandlerTest {
   private final String CLUB_NAME = "KIA 타이거즈";
 
   private ClubsEntity club;
+  private List<ClubsEntity> clubsEntities;
+  private List<Clubs> clubsList;
 
   @BeforeEach
   void setUp() {
     club = ClubsEntity.builder()
         .clubId(1L)
-        .clubName("KIA 타이거즈")
+        .clubName(CLUB_NAME)
         .clubStadium("광주 기아 챔피언스 필드")
         .sports(SportsEntity.builder().sportId(1L).build())
         .emblemImg("imageUrl1")
         .introduction(null)
         .reservationSite(ReservationSiteEntity.builder().reservationSiteId(1L).build())
         .build();
+
+    clubsEntities = List.of(
+        ClubsEntity.builder()
+            .clubId(1L)
+            .clubName("KIA 타이거즈")
+            .clubStadium("광주 기아 챔피언스 필드")
+            .sports(SportsEntity.builder().sportId(1L).build())
+            .emblemImg("imageUrl1")
+            .introduction(null)
+            .reservationSite(ReservationSiteEntity.builder().reservationSiteId(1L).build())
+            .build(),
+        ClubsEntity.builder()
+            .clubId(2L)
+            .clubName("삼성 라이온즈")
+            .clubStadium("대구 삼성 라이온즈 파크")
+            .sports(SportsEntity.builder().sportId(1L).build())
+            .emblemImg("imageUrl2")
+            .introduction(null)
+            .reservationSite(ReservationSiteEntity.builder().reservationSiteId(1L).build())
+            .build()
+    );
+
+    clubsList = clubsEntities.stream()
+        .map(clubsEntity -> new Clubs(clubsEntity.getClubId(), clubsEntity.getClubName()))
+        .toList();
   }
 
   @Test
@@ -54,4 +83,16 @@ class ClubsHandlerTest {
     assertEquals(response, club);
   }
 
+  @Test
+  @DisplayName("getAllClubList : 모든 구단 정보 반환 성공")
+  void shouldReturnClubList() {
+    // given
+    when(clubsRepository.findAll()).thenReturn(clubsEntities);
+
+    // when
+    List<Clubs> response = clubsHandler.getAllClubList();
+
+    // then
+    assertEquals(clubsList.size(), response.size());
+  }
 }

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/ClubsServiceImplTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/ClubsServiceImplTest.java
@@ -3,6 +3,7 @@ package com.service.sport_companion.api.service.impl;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+import com.service.sport_companion.api.component.ClubsHandler;
 import com.service.sport_companion.domain.entity.ClubsEntity;
 import com.service.sport_companion.domain.entity.ReservationSiteEntity;
 import com.service.sport_companion.domain.entity.SportsEntity;
@@ -23,18 +24,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ClubsServiceImplTest {
 
   @Mock
-  private ClubsRepository clubsRepository;
+  private ClubsHandler clubsHandler;
 
   @InjectMocks
   private ClubsServiceImpl clubsService;
 
-  private List<ClubsEntity> clubsEntities;
   private List<Clubs> clubsList;
 
   @BeforeEach
   void setUp() {
     // 가짜 ClubsEntity 리스트 생성
-    clubsEntities = List.of(
+    List<ClubsEntity> clubsEntities = List.of(
         ClubsEntity.builder()
             .clubId(1L)
             .clubName("KIA 타이거즈")
@@ -57,7 +57,7 @@ class ClubsServiceImplTest {
 
     // 가짜 Clubs 리스트 생성
     clubsList = clubsEntities.stream()
-        .map(clubsEntity -> new Clubs(clubsEntity.getClubName(), clubsEntity.getEmblemImg()))
+        .map(clubsEntity -> new Clubs(clubsEntity.getClubId(), clubsEntity.getClubName()))
         .toList();
   }
 
@@ -65,7 +65,7 @@ class ClubsServiceImplTest {
   @DisplayName("모든 클럽 리스트 가져오기 성공")
   void getAllClubListSuccessfully() {
     // given
-    when(clubsRepository.findAll()).thenReturn(clubsEntities);
+    when(clubsHandler.getAllClubList()).thenReturn(clubsList);
 
     // when
     ResultResponse resultResponse = clubsService.getAllClubList();

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/clubs/Clubs.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/clubs/Clubs.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class Clubs {
 
+  Long clubId;
   String clubName;
-  String emblemImg;
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
모든 구단 조회시 전달 데이터 수정
- 기존 방식에서 전달 하는 데이터
   - clubName, emblemImg
- 변경 후 전달 하는 데이터
   - clubId, clubName

ClubsServiceImpl
- 해당 클래스에서 ClubsRepository를 사용을 했지만, ClubsHandler 클래스를 사용하는 방식으로 수정

## 스크린샷

## 주의사항

Closes #38 
