### PR TITLE
[fix] 뉴스 링크 저장 형식 절대 경로로 수정

### DIFF
--- a/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/news/MbcNewsCrawling.java
+++ b/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/news/MbcNewsCrawling.java
@@ -5,6 +5,7 @@ import com.service.sport_companion.core.exception.GlobalException;
 import com.service.sport_companion.domain.entity.NewsEntity;
 import com.service.sport_companion.domain.model.type.FailedResultType;
 import com.service.sport_companion.domain.model.type.NewsType;
+import com.service.sport_companion.domain.model.type.UrlType;
 import jakarta.transaction.Transactional;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -33,7 +34,7 @@ import org.springframework.stereotype.Component;
 public class MbcNewsCrawling {
 
   private final WebDriverHandler webDriverHandler;
-  private final String baseUrl = "https://imnews.imbc.com";
+  private final String baseUrl = UrlType.MBC_NEWS_URL.getUrl();
 
   // 배치로 실행시킬 MBC News 크롤링 메인 작업
   @Transactional

--- a/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/news/MbcNewsCrawling.java
+++ b/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/news/MbcNewsCrawling.java
@@ -33,11 +33,12 @@ import org.springframework.stereotype.Component;
 public class MbcNewsCrawling {
 
   private final WebDriverHandler webDriverHandler;
+  private final String baseUrl = "https://imnews.imbc.com";
 
   // 배치로 실행시킬 MBC News 크롤링 메인 작업
   @Transactional
   public List<NewsEntity> crawlingMain() {
-    String url = "https://imnews.imbc.com/more/search/?mainSearch=%EC%95%BC%EA%B5%AC";
+    String url = baseUrl + "/more/search/?mainSearch=%EC%95%BC%EA%B5%AC";
     int pageSize = 5;
 
     WebDriver driver = webDriverHandler.getWebDriver(url);
@@ -110,7 +111,7 @@ public class MbcNewsCrawling {
       }
 
       newsItemList.add(NewsEntity.builder()
-        .newsLink(newsLink)
+        .newsLink(baseUrl + newsLink)
         .thumbnail(thumbnail)
         .headline(headline)
         .newsType(newsType)

--- a/sport_companion/module-batch/src/test/java/com/service/sport_companion/batch/news/MbcNewsCrawlingTest.java
+++ b/sport_companion/module-batch/src/test/java/com/service/sport_companion/batch/news/MbcNewsCrawlingTest.java
@@ -22,6 +22,7 @@ class MbcNewsCrawlingTest {
   @DisplayName("parsing : html에서 정확히 파싱하는지 테스트")
   void parsingSuccess() {
     // given
+    String baseUrl = "https://imnews.imbc.com";
     String html = """
             <body>
               <div class="result_list">
@@ -50,7 +51,7 @@ class MbcNewsCrawlingTest {
     assertEquals(result.size(), 1);
     assertEquals(result.get(0).getHeadline(), "headline");
     assertEquals(result.get(0).getThumbnail(), "img_url");
-    assertEquals(result.get(0).getNewsLink(), "href_url");
+    assertEquals(result.get(0).getNewsLink(), baseUrl + "href_url");
     assertEquals(result.get(0).getNewsDate(), LocalDate.now());
     assertEquals(result.get(0).getNewsType(), NewsType.VIDEO);
   }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/UrlType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/UrlType.java
@@ -11,6 +11,7 @@ public enum UrlType {
   SIGNUP_URL("http://localhost:3000/signUp"),
   FRONT_LOCAL_URL("http://localhost:3000"),
   FRONT_VERCEL_URL("https://front-end-jet-psi.vercel.app"),
+  MBC_NEWS_URL("https://imnews.imbc.com"),
   ;
 
   private final String url;


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
**MbcNewsCrawling**
- 관리하기 쉽도록 도메인 주소 baseUrl를 전역 변수로 저장
- baseUrl에 크롤링해서 가져온 경로를 더해서 DB에 저장

## 스크린샷
![image](https://github.com/user-attachments/assets/22388cd5-191e-4290-84c7-046fec2c9c17)

## 주의사항

Closes #41