### PR TITLE
[refactor] ResultResponse의 data를 제너릭 타입으로 수정

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/AuthController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/AuthController.java
@@ -44,24 +44,24 @@ public class AuthController {
   }
 
   @GetMapping("/check-nickname/{nickname}")
-  public ResponseEntity<ResultResponse> checkNickname(
+  public ResponseEntity<ResultResponse<Boolean>> checkNickname(
     @NotBlank(message = "닉네임을 입력해 주세요.") @PathVariable("nickname") String nickname) {
 
     return ResponseEntity.ok(authService.checkNickname(nickname));
   }
 
   @PostMapping("/signup")
-  public ResponseEntity<ResultResponse> signup(@RequestBody @Valid SignUpDto signUpDto) {
+  public ResponseEntity<ResultResponse<Void>> signup(@RequestBody @Valid SignUpDto signUpDto) {
 
-    ResultResponse response = authService.signup(signUpDto);
+    ResultResponse<Void> response = authService.signup(signUpDto);
     return new ResponseEntity<>(response, response.getStatus());
   }
 
   @GetMapping("/reissue-token")
-  public ResponseEntity<ResultResponse> reissueToken(
+  public ResponseEntity<ResultResponse<Void>> reissueToken(
       HttpServletRequest request, HttpServletResponse response) {
 
-    ResultResponse resultResponse = authService.reissueToken(request, response);
+    ResultResponse<Void> resultResponse = authService.reissueToken(request, response);
     return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/ClubsController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/ClubsController.java
@@ -2,6 +2,8 @@ package com.service.sport_companion.api.controller;
 
 import com.service.sport_companion.api.service.ClubsService;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.clubs.Clubs;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,9 +18,9 @@ public class ClubsController {
   private final ClubsService clubsService;
 
   @GetMapping("/all")
-  public ResponseEntity<ResultResponse> getAllClubs() {
+  public ResponseEntity<ResultResponse<List<Clubs>>> getAllClubs() {
 
-    ResultResponse response = clubsService.getAllClubList();
+    ResultResponse<List<Clubs>> response = clubsService.getAllClubList();
     return new ResponseEntity<>(response, response.getStatus());
   }
 

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
@@ -11,11 +11,11 @@ public interface AuthService {
   String oAuthForKakao(String code, HttpServletRequest request, HttpServletResponse response);
 
   // 닉네임 중복 확인
-  ResultResponse checkNickname(String nickname);
+  ResultResponse<Boolean> checkNickname(String nickname);
 
   // 회원가입 추가 데이터 저장
-  ResultResponse signup(SignUpDto signUpDto);
+  ResultResponse<Void> signup(SignUpDto signUpDto);
 
   // Jwt 토큰 재발급 로직
-  ResultResponse reissueToken(HttpServletRequest request, HttpServletResponse response);
+  ResultResponse<Void> reissueToken(HttpServletRequest request, HttpServletResponse response);
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/ClubsService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/ClubsService.java
@@ -1,8 +1,10 @@
 package com.service.sport_companion.api.service;
 
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.clubs.Clubs;
+import java.util.List;
 
 public interface ClubsService {
 
-  ResultResponse getAllClubList();
+  ResultResponse<List<Clubs>> getAllClubList();
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
@@ -96,18 +96,18 @@ public class AuthServiceImpl implements AuthService {
 
   // 닉네임 중복 검증
   @Override
-  public ResultResponse checkNickname(String nickname) {
+  public ResultResponse<Boolean> checkNickname(String nickname) {
     boolean isValidNickname = !userHandler.existsByNickname(nickname);
 
     SuccessResultType resultType = (isValidNickname) ?
       SuccessResultType.AVAILABLE_NICKNAME : SuccessResultType.UNAVAILABLE_NICKNAME;
 
-    return new ResultResponse(resultType, isValidNickname);
+    return new ResultResponse<>(resultType, isValidNickname);
   }
 
   // 회원가입
   @Override
-  public ResultResponse signup(SignUpDto signUpDto) {
+  public ResultResponse<Void> signup(SignUpDto signUpDto) {
     // 1. Redis에서 사용자 데이터 가져오기
     SignUpDataEntity signUpData = redisHandler.getSignUpDataByProviderId(signUpDto.getProviderId());
 
@@ -146,7 +146,7 @@ public class AuthServiceImpl implements AuthService {
   }
 
   @Override
-  public ResultResponse reissueToken(HttpServletRequest request, HttpServletResponse response) {
+  public ResultResponse<Void> reissueToken(HttpServletRequest request, HttpServletResponse response) {
     Cookie[] cookies = request.getCookies();
 
     // 쿠키 검증

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/ClubsServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/ClubsServiceImpl.java
@@ -19,12 +19,12 @@ public class ClubsServiceImpl implements ClubsService {
 
   // 모든 구단 조회
   @Override
-  public ResultResponse getAllClubList() {
+  public ResultResponse<List<Clubs>> getAllClubList() {
     // 다른 종목 추가시 수정할 예정
     List<Clubs> clubList = clubsRepository.findAll().stream()
         .map(clubsEntity -> new Clubs(clubsEntity.getClubName(), clubsEntity.getEmblemImg()))
         .toList();
 
-    return new ResultResponse(SuccessResultType.SUCCESS_GET_ALL_CLUBS_LIST, clubList);
+    return new ResultResponse<>(SuccessResultType.SUCCESS_GET_ALL_CLUBS_LIST, clubList);
   }
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/ResultResponse.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/ResultResponse.java
@@ -7,33 +7,33 @@ import org.springframework.http.HttpStatus;
 
 
 @Getter
-public class ResultResponse {
+public class ResultResponse<T> {
 
   private final Integer code;
   private final HttpStatus status;
   private final String message;
-  private final Object data;
+  private final T data;
 
-  public ResultResponse(SuccessResultType successResultCode, Object data) {
+  public ResultResponse(SuccessResultType successResultCode, T data) {
     this.code = successResultCode.getStatus().value();
     this.status = successResultCode.getStatus();
     this.message = successResultCode.getMessage();
     this.data = data;
   }
 
-  public ResultResponse(FailedResultType failedResultCode,  Object data) {
+  public ResultResponse(FailedResultType failedResultCode,  T data) {
     this.code = failedResultCode.getStatus().value();
     this.status = failedResultCode.getStatus();
     this.message = failedResultCode.getMessage();
     this.data = data;
   }
 
-  public static ResultResponse of(SuccessResultType successResultCode) {
-    return new ResultResponse(successResultCode, null);
+  public static ResultResponse<Void> of(SuccessResultType successResultCode) {
+    return new ResultResponse<>(successResultCode, null);
   }
 
-  public static ResultResponse of(FailedResultType failedResultCode) {
-    return new ResultResponse(failedResultCode, null);
+  public static ResultResponse<Void> of(FailedResultType failedResultCode) {
+    return new ResultResponse<>(failedResultCode, null);
   }
 
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
**ResultResponse**
- Object대신 제너릭 타입을 사용해서 자료형 명시하여 사용하도록 설정
- 기존에 ResultResponse를 사용하던 Controller, Service, ServiceImpl 수정

## 스크린샷

## 주의사항
- 병합 시 충돌 주의

Closes #45
