### PR TITLE
[feat] 주제(CustomTopic) 생성 및 삭제 API 구현

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicHandler.java
@@ -26,4 +26,8 @@ public class CustomTopicHandler {
     return customTopicRepository.findById(topicId)
       .orElseThrow(() -> new GlobalException(FailedResultType.CUSTOM_TOPIC_NOT_FOUND));
   }
+
+  public void deleteTopic(Long topicId) {
+    customTopicRepository.deleteById(topicId);
+  }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicHandler.java
@@ -1,0 +1,29 @@
+package com.service.sport_companion.api.component;
+
+import com.service.sport_companion.core.exception.GlobalException;
+import com.service.sport_companion.domain.entity.CustomTopicEntity;
+import com.service.sport_companion.domain.entity.UsersEntity;
+import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto;
+import com.service.sport_companion.domain.model.type.FailedResultType;
+import com.service.sport_companion.domain.repository.CustomTopicRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomTopicHandler {
+
+  private final CustomTopicRepository customTopicRepository;
+
+  public void saveTopic(UsersEntity userEntity, CreateTopicDto createTopicDto) {
+    customTopicRepository.save(CustomTopicEntity.builder()
+        .topic(createTopicDto.getTopic())
+        .users(userEntity)
+      .build());
+  }
+
+  public CustomTopicEntity findById(Long topicId) {
+    return customTopicRepository.findById(topicId)
+      .orElseThrow(() -> new GlobalException(FailedResultType.CUSTOM_TOPIC_NOT_FOUND));
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/CustomTopicController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/CustomTopicController.java
@@ -1,0 +1,29 @@
+package com.service.sport_companion.api.controller;
+
+import com.service.sport_companion.api.service.CustomTopicService;
+import com.service.sport_companion.domain.model.annotation.CallUser;
+import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/topic")
+public class CustomTopicController {
+
+  private final CustomTopicService customTopicService;
+
+  @PostMapping
+  public ResponseEntity<ResultResponse<Void>> createTopic(@CallUser Long userId,
+    @RequestBody CreateTopicDto createTopicDto
+  ) {
+    ResultResponse<Void> response = customTopicService.createTopic(userId, createTopicDto);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/CustomTopicController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/CustomTopicController.java
@@ -6,6 +6,8 @@ import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +25,15 @@ public class CustomTopicController {
     @RequestBody CreateTopicDto createTopicDto
   ) {
     ResultResponse<Void> response = customTopicService.createTopic(userId, createTopicDto);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @DeleteMapping("/{topicId}")
+  public ResponseEntity<ResultResponse<Void>> deleteTopic(@CallUser Long userId,
+    @PathVariable("topicId") Long topicId
+  ) {
+    ResultResponse<Void> response = customTopicService.deleteTopic(userId, topicId);
 
     return new ResponseEntity<>(response, response.getStatus());
   }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/CustomTopicService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/CustomTopicService.java
@@ -1,0 +1,9 @@
+package com.service.sport_companion.api.service;
+
+import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+
+public interface CustomTopicService {
+
+  ResultResponse<Void> createTopic(Long userId, CreateTopicDto createTopicDto);
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/CustomTopicService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/CustomTopicService.java
@@ -6,4 +6,6 @@ import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 public interface CustomTopicService {
 
   ResultResponse<Void> createTopic(Long userId, CreateTopicDto createTopicDto);
+
+  ResultResponse<Void> deleteTopic(Long userId, Long topicId);
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImpl.java
@@ -1,0 +1,33 @@
+package com.service.sport_companion.api.service.impl;
+
+import com.service.sport_companion.api.component.CustomTopicHandler;
+import com.service.sport_companion.api.component.UserHandler;
+import com.service.sport_companion.api.service.CustomTopicService;
+import com.service.sport_companion.core.exception.GlobalException;
+import com.service.sport_companion.domain.entity.CustomTopicEntity;
+import com.service.sport_companion.domain.entity.UsersEntity;
+import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.type.FailedResultType;
+import com.service.sport_companion.domain.model.type.SuccessResultType;
+import com.service.sport_companion.domain.model.type.UserRole;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CustomTopicServiceImpl implements CustomTopicService {
+
+  private final CustomTopicHandler customTopicHandler;
+  private final UserHandler userHandler;
+
+  @Override
+  public ResultResponse<Void> createTopic(Long userId, CreateTopicDto createTopicDto) {
+    UsersEntity userEntity = userHandler.findByUserId(userId);
+    customTopicHandler.saveTopic(userEntity, createTopicDto);
+
+    return ResultResponse.of(SuccessResultType.SUCCESS_CREATE_CUSTOM_TOPIC);
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImpl.java
@@ -30,4 +30,20 @@ public class CustomTopicServiceImpl implements CustomTopicService {
 
     return ResultResponse.of(SuccessResultType.SUCCESS_CREATE_CUSTOM_TOPIC);
   }
+
+  @Override
+  public ResultResponse<Void> deleteTopic(Long userId, Long topicId) {
+    UsersEntity userEntity = userHandler.findByUserId(userId);
+    CustomTopicEntity customTopicEntity = customTopicHandler.findById(topicId);
+
+    // 작성자이거나 관리자인 경우 삭제할 수 있다.
+    if (!customTopicEntity.getUsers().equals(userEntity)
+      && !userEntity.getRole().equals(UserRole.ADMIN)) {
+      throw new GlobalException(FailedResultType.DELETE_TOPIC_FORBIDDEN);
+    }
+
+    customTopicHandler.deleteTopic(topicId);
+
+    return ResultResponse.of(SuccessResultType.SUCCESS_DELETE_CUSTOM_TOPIC);
+  }
 }

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImplTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImplTest.java
@@ -1,0 +1,108 @@
+package com.service.sport_companion.api.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import com.service.sport_companion.api.component.CustomTopicHandler;
+import com.service.sport_companion.api.component.UserHandler;
+import com.service.sport_companion.core.exception.GlobalException;
+import com.service.sport_companion.domain.entity.CustomTopicEntity;
+import com.service.sport_companion.domain.entity.UsersEntity;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.type.SuccessResultType;
+import com.service.sport_companion.domain.model.type.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class CustomTopicServiceImplTest {
+
+  @InjectMocks
+  private CustomTopicServiceImpl customTopicService;
+
+  @Mock
+  private CustomTopicHandler customTopicHandler;
+
+  @Mock
+  private UserHandler userHandler;
+
+  private final long AUTHOR_ID = 1L;
+  private final long TOPIC_ID = 2L;
+  private UsersEntity author;
+  private CustomTopicEntity topic;
+
+  @BeforeEach
+  public void setup() {
+    author = UsersEntity.builder()
+      .userId(AUTHOR_ID)
+      .role(UserRole.USER)
+      .build();
+
+    topic = CustomTopicEntity.builder()
+      .users(author)
+      .build();
+  }
+
+  @Test
+  @DisplayName("자신이 등록한 Topic 삭제_성공")
+  public void deleteMyTopic() {
+    // given
+    given(userHandler.findByUserId(AUTHOR_ID)).willReturn(author);
+    given(customTopicHandler.findById(TOPIC_ID)).willReturn(topic);
+
+    // when
+    ResultResponse<Void> response = customTopicService.deleteTopic(AUTHOR_ID, TOPIC_ID);
+
+    // then
+    assertEquals(response.getMessage(), SuccessResultType.SUCCESS_DELETE_CUSTOM_TOPIC.getMessage());
+    assertEquals(response.getStatus(), HttpStatus.OK);
+    assertNull(response.getData());
+  }
+
+  @Test
+  @DisplayName("관리자 Topic 삭제_성공")
+  public void deleteTopicByAdmin() {
+    // given
+    long adminId = 2L;
+    UsersEntity admin = UsersEntity.builder()
+      .userId(adminId)
+      .role(UserRole.ADMIN)
+      .build();
+
+    given(userHandler.findByUserId(adminId)).willReturn(admin);
+    given(customTopicHandler.findById(TOPIC_ID)).willReturn(topic);
+
+    // when
+    ResultResponse<Void> response = customTopicService.deleteTopic(adminId, TOPIC_ID);
+
+    // then
+    assertEquals(response.getMessage(), SuccessResultType.SUCCESS_DELETE_CUSTOM_TOPIC.getMessage());
+    assertEquals(response.getStatus(), HttpStatus.OK);
+    assertNull(response.getData());
+  }
+
+  @Test
+  @DisplayName("다른 사람 토픽 삭제_실패")
+  public void deleteTopicByOther() {
+    // given
+    long otherUserId = 3L;
+    UsersEntity otherUser = UsersEntity.builder()
+      .userId(otherUserId)
+      .role(UserRole.USER)
+      .build();
+
+    given(userHandler.findByUserId(otherUserId)).willReturn(otherUser);
+    given(customTopicHandler.findById(TOPIC_ID)).willReturn(topic);
+
+    // when & then
+    assertThrows(GlobalException.class, () -> customTopicService.deleteTopic(otherUserId, TOPIC_ID));
+  }
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/CustomTopicEntity.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/CustomTopicEntity.java
@@ -1,0 +1,43 @@
+package com.service.sport_companion.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "custom_topic")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class CustomTopicEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long customTopicId;
+
+  @ManyToOne
+  @JoinColumn(name = "users_id", nullable = false)
+  private UsersEntity users;
+
+  private String topic;
+
+  @Builder.Default
+  private Long voteCount = 0L;
+
+  @CreatedDate
+  private LocalDateTime createdAt;
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/request/topic/CreateTopicDto.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/request/topic/CreateTopicDto.java
@@ -1,0 +1,19 @@
+package com.service.sport_companion.domain.model.dto.request.topic;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateTopicDto {
+
+  @JsonProperty("topic")
+  private String topic;
+
+  @JsonCreator
+  public CreateTopicDto(String topic) {
+    this.topic = topic;
+  }
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
@@ -23,7 +23,11 @@ public enum FailedResultType {
   USER_INFO_RETRIEVAL(HttpStatus.UNAUTHORIZED, "사용자 정보를 가져오는 데 실패했습니다."),
 
   // Crawling
-  MBC_NEWS_PARSING_FAILED(HttpStatus.BAD_GATEWAY, "MBC 뉴스 파싱에 실패했습니다.")
+  MBC_NEWS_PARSING_FAILED(HttpStatus.BAD_GATEWAY, "MBC 뉴스 파싱에 실패했습니다."),
+
+  // CustomTopic
+  CUSTOM_TOPIC_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 주제입니다."),
+  DELETE_TOPIC_FORBIDDEN(HttpStatus.FORBIDDEN, "주제 삭제 권한이 없습니다"),
   ;
 
   private final HttpStatus status;

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -22,6 +22,10 @@ public enum SuccessResultType {
   // News
   SUCCESS_GET_NEWS_LIST(HttpStatus.OK, "뉴스를 성공적으로 조회했습니다."),
 
+  // CustomTopic
+  SUCCESS_CREATE_CUSTOM_TOPIC(HttpStatus.CREATED, "주제가 작성되었습니다."),
+  SUCCESS_DELETE_CUSTOM_TOPIC(HttpStatus.OK, "주제가 삭제되었습니다"),
+
   ;
 
   private final HttpStatus status;

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRepository.java
@@ -1,0 +1,10 @@
+package com.service.sport_companion.domain.repository;
+
+import com.service.sport_companion.domain.entity.CustomTopicEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomTopicRepository extends JpaRepository<CustomTopicEntity, Long> {
+
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
**CustomTopicEntity / CustomTopicRepository**
- CustomTopic Entity와 Repository 생성

**CustomTopicController**
- 사용자 주제 생성 API 구현 (로그인 필요)
- 사용자 주제 삭제 API 구현 (로그인 필요)

**CustomTopicService(Impl)**
- 사용자 주제 생성을 위해 파라미터로 받은 주제를 Handler를 통해 DB에 저장
- 사용자 주제 삭제를 위해 삭제 권한이 있는지(작성자이거나 관리자) 체크하고 Handler를 통해 DB에서 삭제

**CustomTopicHandler**
- Repository에 접근하여 DB에서 Topic을 저장, 삭제, 조회하는 메서드 구현

## 스크린샷

## 주의사항

Closes #44
