### PR TITLE
[feat] 경기 일정 크롤링 API 구현

### DIFF
--- a/sport_companion/module-api/build.gradle
+++ b/sport_companion/module-api/build.gradle
@@ -33,6 +33,11 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Selenium
+    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.26.0'
+
+    // jsoup
+    implementation 'org.jsoup:jsoup:1.18.1'
 }
 
 

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtFilter.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtFilter.java
@@ -106,6 +106,7 @@ public class JwtFilter extends OncePerRequestFilter {
     return pathMatcher.match("/", requestURI)
         || pathMatcher.match("/api/v1/auth/**", requestURI)
         || pathMatcher.match("/api/v1/clubs/all", requestURI)
+        || pathMatcher.match("/api/v1/fixture/crawl", requestURI)
         || pathMatcher.match("/v3/api-docs/**", requestURI)
         || pathMatcher.match("/swagger-ui/**", requestURI)
         || pathMatcher.match("/swagger-ui.html", requestURI)

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/ClubsHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/ClubsHandler.java
@@ -22,4 +22,8 @@ public class ClubsHandler {
         .map(clubsEntity -> new Clubs(clubsEntity.getClubId(), clubsEntity.getClubName()))
         .toList();
   }
+
+  public ClubsEntity findByFieldContaining(String clubName) {
+    return clubsRepository.findByFieldContaining(clubName);
+  }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/ClubsHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/ClubsHandler.java
@@ -24,6 +24,6 @@ public class ClubsHandler {
   }
 
   public ClubsEntity findByFieldContaining(String clubName) {
-    return clubsRepository.findByFieldContaining(clubName);
+    return clubsRepository.findByClubNameContaining(clubName);
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/FixtureHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/FixtureHandler.java
@@ -1,0 +1,19 @@
+package com.service.sport_companion.api.component;
+
+import com.service.sport_companion.domain.entity.FixturesEntity;
+import com.service.sport_companion.domain.repository.FixturesRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FixtureHandler {
+
+  private final FixturesRepository fixturesRepository;
+
+
+  public void saveFixtureList(List<FixturesEntity> fixturesList) {
+    fixturesRepository.saveAll(fixturesList);
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/SeasonHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/SeasonHandler.java
@@ -1,0 +1,18 @@
+package com.service.sport_companion.api.component;
+
+import com.service.sport_companion.domain.entity.SeasonsEntity;
+import com.service.sport_companion.domain.repository.SeasonsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SeasonHandler {
+
+  private final SeasonsRepository seasonsRepository;
+
+  public SeasonsEntity findBySeasonName(String seasonName) {
+    return seasonsRepository.findBySeasonName(seasonName);
+  }
+
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/crawl/CrawlFixtures.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/crawl/CrawlFixtures.java
@@ -116,7 +116,7 @@ public class CrawlFixtures {
     }
   }
 
-  private FixturesEntity parseToFixturesEntity(String year, String lastDate, Element schedule, String key) {
+  public FixturesEntity parseToFixturesEntity(String year, String lastDate, Element schedule, String key) {
     // 날짜 파싱
     LocalDate fixtureDate = (lastDate != null) ? parseToLocalDate(year, lastDate) : null;
 

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/crawl/CrawlFixtures.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/crawl/CrawlFixtures.java
@@ -1,0 +1,195 @@
+package com.service.sport_companion.api.component.crawl;
+
+import com.service.sport_companion.api.component.ClubsHandler;
+import com.service.sport_companion.api.component.FixtureHandler;
+import com.service.sport_companion.api.component.SeasonHandler;
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.entity.FixturesEntity;
+import com.service.sport_companion.domain.entity.SeasonsEntity;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.safari.SafariDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CrawlFixtures {
+
+  private final SeasonHandler seasonHandler;
+  private final ClubsHandler clubsHandler;
+  private final FixtureHandler fixtureHandler;
+
+  public void crawlFixtures(String year) {
+    WebDriver driver = new SafariDriver();
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+
+    Map<String, String> seriesMap = new HashMap<>();
+    seriesMap.put("KBO 시범경기 일정", "1");
+    seriesMap.put("KBO 정규시즌 일정", "0,9,6");
+    seriesMap.put("KBO 포스트시즌 일정", "3,4,5,7");
+
+
+    try {
+      driver.get("https://www.koreabaseball.com/Schedule/Schedule.aspx#");
+      driver.manage().window().maximize();
+
+      for (Entry<String, String> series : seriesMap.entrySet()) {
+
+        log.info("Series : {}}", series.getKey());
+
+        // JavaScript로 `ddlSeries` 드롭다운 값을 설정
+        JavascriptExecutor js = (JavascriptExecutor) driver;
+        js.executeScript("document.getElementById('ddlSeries').value = '" + series.getValue() + "';");
+        js.executeScript("document.getElementById('ddlSeries').dispatchEvent(new Event('change'));");
+
+        // 각 월에 대해 크롤링
+        for (int month = 1; month <= 12; month++) {
+          List<FixturesEntity> fixturesList = new ArrayList<>();
+          log.info("month = {}", month);
+
+          // 연도 선택
+          Select yearSelect = new Select(driver.findElement(By.id("ddlYear")));
+          yearSelect.selectByVisibleText(year);
+
+          // 월 선택
+          String formattedMonth = String.format("%02d", month);
+          Select monthSelect = new Select(driver.findElement(By.id("ddlMonth")));
+          monthSelect.selectByVisibleText(formattedMonth);
+
+          // 페이지 로드 완료 대기
+          wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("#tblScheduleList > tbody > tr")));
+
+          // Jsoup으로 HTML 파싱
+          Document doc = Jsoup.parse(driver.getPageSource());
+          Elements baseballSchedule = doc.select("#tblScheduleList > tbody > tr");
+
+          String lastDate = null; // 마지막으로 추출한 날짜를 저장
+
+          for (Element schedule : baseballSchedule) {
+            // 날짜가 있으면 업데이트, 없으면 이전 날짜 사용
+            Element dayElement = schedule.selectFirst("td.day");
+            if (dayElement != null) {
+              lastDate = dayElement.text();
+            }
+
+            FixturesEntity fixtures = parseToFixturesEntity(year, lastDate, schedule, series.getKey());
+
+            if (fixtures != null) {
+              fixturesList.add(fixtures);
+
+              // 로그 출력
+              log.info("날짜: {}", fixtures.getFixtureDate());
+              log.info("시간: {}", fixtures.getFixtureTime());
+              log.info("홈팀: {} ({})", fixtures.getHomeClub().getClubName(), fixtures.getHomeScore());
+              log.info("원정팀: {} ({})", fixtures.getAwayClub().getClubName(), fixtures.getAwayScore());
+              log.info("장소: {}", fixtures.getStadium());
+              log.info("비고: {}", fixtures.getNotes());
+              log.info("----------------------------");
+            }
+          }
+          fixtureHandler.saveFixtureList(fixturesList);
+        } // month for end
+      } // season for end
+    } catch (Exception e) {
+      log.error("크롤링 중 오류 발생: ", e);
+    } finally {
+      driver.quit();
+    }
+  }
+
+  private FixturesEntity parseToFixturesEntity(String year, String lastDate, Element schedule, String key) {
+    // 날짜 파싱
+    LocalDate fixtureDate = (lastDate != null) ? parseToLocalDate(year, lastDate) : null;
+
+    // 시간 파싱
+    Element fixtureTimeElement = schedule.selectFirst("td.time > b");
+    String fixtureTime = (fixtureTimeElement != null) ? fixtureTimeElement.text() : null;
+
+    // 팀 이름 파싱 및 DB 조회
+    Element homeClubElement = schedule.selectFirst("td.play > span:nth-child(1)");
+    ClubsEntity homeClub = (homeClubElement != null) ? clubsHandler.findByFieldContaining(homeClubElement.text()) : null;
+
+    Element awayClubElement = schedule.selectFirst("td.play > span:nth-child(3)");
+    ClubsEntity awayClub = (awayClubElement != null) ? clubsHandler.findByFieldContaining(awayClubElement.text()) : null;
+
+    // 점수 파싱
+    Element homeScoreElement = null;
+    Element awayScoreElement = null;
+
+    // em 태그 내 span 태그의 개수를 확인
+    Elements scoreSpans = schedule.select("td.play em > span");
+    if (scoreSpans.size() >= 3) {
+      // span 태그가 3개 이상인 경우 점수 파싱
+      homeScoreElement = scoreSpans.get(0); // 첫 번째 span
+      awayScoreElement = scoreSpans.get(2); // 세 번째 span
+    }
+
+    // 점수를 가져오거나 "-"로 설정
+    String homeScore = (homeScoreElement != null) ? homeScoreElement.text() : "-";
+    String awayScore = (awayScoreElement != null) ? awayScoreElement.text() : "-";
+
+    // 경기장 및 비고
+    int tdCount = schedule.select("td").size();
+    int locationIndex = (tdCount > 8) ? 7 : 6;
+    int notesIndex = locationIndex + 1;
+
+    // 경기장 및 비고
+    String stadium = (tdCount > locationIndex) ? schedule.select("td").get(locationIndex).text() : "-";
+    String notes = (tdCount > notesIndex) ? schedule.select("td").get(notesIndex).text() : "-";
+
+
+    // 중요 필드가 null인 경우 저장하지 않음
+    if (fixtureDate == null || fixtureTime == null || homeClub == null || awayClub == null) {
+      log.warn("중요 필드가 null 입니다. 저장하지 않습니다: fixtureDate={}, fixtureTime={}, homeClub={}, awayClub={}",
+          fixtureDate, fixtureTime, homeClub, awayClub);
+      return null;
+    }
+
+    SeasonsEntity seasons = seasonHandler.findBySeasonName(key);
+
+    // FixturesEntity 생성
+    return FixturesEntity.builder()
+        .seasons(seasons)
+        .fixtureDate(fixtureDate)
+        .fixtureTime(fixtureTime)
+        .homeClub(homeClub)
+        .homeScore(homeScore)
+        .awayClub(awayClub)
+        .awayScore(awayScore)
+        .stadium(stadium)
+        .notes(notes)
+        .build();
+  }
+
+  private LocalDate parseToLocalDate(String year, String dayElement) {
+    String date = dayElement.replaceAll("\\(.*\\)", "").trim();
+
+    // DateTimeFormatter 생성
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    // 연도와 날짜를 결합
+    String fullDate = year + "." + date;
+
+    // LocalDate 변환
+    return LocalDate.parse(fullDate, formatter);
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/crawl/CrawlFixtures.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/crawl/CrawlFixtures.java
@@ -8,6 +8,7 @@ import com.service.sport_companion.domain.entity.FixturesEntity;
 import com.service.sport_companion.domain.entity.SeasonsEntity;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -122,7 +123,7 @@ public class CrawlFixtures {
 
     // 시간 파싱
     Element fixtureTimeElement = schedule.selectFirst("td.time > b");
-    String fixtureTime = (fixtureTimeElement != null) ? fixtureTimeElement.text() : null;
+    LocalTime fixtureTime = (fixtureTimeElement != null) ? LocalTime.parse(fixtureTimeElement.text()) : null;
 
     // 팀 이름 파싱 및 DB 조회
     Element homeClubElement = schedule.selectFirst("td.play > span:nth-child(1)");
@@ -144,8 +145,8 @@ public class CrawlFixtures {
     }
 
     // 점수를 가져오거나 "-"로 설정
-    String homeScore = (homeScoreElement != null) ? homeScoreElement.text() : "-";
-    String awayScore = (awayScoreElement != null) ? awayScoreElement.text() : "-";
+    int homeScore = (homeScoreElement != null) ? Integer.parseInt(awayScoreElement.text()) : 0;
+    int awayScore = (awayScoreElement != null) ? Integer.parseInt(awayScoreElement.text()) : 0;
 
     // 경기장 및 비고
     int tdCount = schedule.select("td").size();

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
             .requestMatchers("/",
                 "/api/v1/auth/**",
                 "/api/v1/clubs/all",
+                "/api/v1/fixture/crawl",
                 "/favicon.ico").permitAll()
             .anyRequest().authenticated());
 

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/AuthController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/AuthController.java
@@ -27,10 +27,10 @@ public class AuthController {
   private final AuthService authService;
 
   @PostMapping("/kakao")
-  public ResponseEntity<ResultResponse> oAuthForKakao(HttpServletResponse response,
+  public ResponseEntity<ResultResponse<?>> oAuthForKakao(HttpServletResponse response,
       @RequestBody @Valid KakaoCodeDto kakaoCode) {
 
-    ResultResponse resultResponse = authService.oAuthForKakao(kakaoCode.getCode(), response);
+    ResultResponse<?> resultResponse = authService.oAuthForKakao(kakaoCode.getCode(), response);
     return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
   }
 

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/FixturesController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/FixturesController.java
@@ -18,9 +18,9 @@ public class FixturesController {
 
   // 추후 변경할 예정
   @GetMapping("/crawl")
-  private ResponseEntity<ResultResponse> crawlFixtures(@RequestParam("year") String year) {
+  private ResponseEntity<ResultResponse<Void>> crawlFixtures(@RequestParam("year") String year) {
 
-    ResultResponse response = fixturesService.crawlFixtures(year);
+    ResultResponse<Void> response = fixturesService.crawlFixtures(year);
     return new ResponseEntity<>(response, response.getStatus());
 
   }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/FixturesController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/FixturesController.java
@@ -1,0 +1,30 @@
+package com.service.sport_companion.api.controller;
+
+import com.service.sport_companion.api.service.FixturesService;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/fixture")
+public class FixturesController {
+
+  private final FixturesService fixturesService;
+
+  // 추후 변경할 예정
+  @GetMapping("/crawl")
+  private ResponseEntity<ResultResponse> crawlFixtures(@RequestParam("year") String year) {
+
+    ResultResponse response = fixturesService.crawlFixtures(year);
+    return new ResponseEntity<>(response, response.getStatus());
+
+  }
+
+
+
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/AuthService.java
@@ -8,7 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 public interface AuthService {
 
   // 카카오 회원가입 or 로그인
-  ResultResponse oAuthForKakao(String code, HttpServletResponse response);
+  ResultResponse<Void> oAuthForKakao(String code, HttpServletResponse response);
 
   // 닉네임 중복 확인
   ResultResponse<Boolean> checkNickname(String nickname);

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/FixturesService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/FixturesService.java
@@ -4,5 +4,5 @@ import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 
 public interface FixturesService {
 
-  ResultResponse crawlFixtures(String year);
+  ResultResponse<Void> crawlFixtures(String year);
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/FixturesService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/FixturesService.java
@@ -1,0 +1,8 @@
+package com.service.sport_companion.api.service;
+
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+
+public interface FixturesService {
+
+  ResultResponse crawlFixtures(String year);
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
@@ -1,0 +1,24 @@
+package com.service.sport_companion.api.service.impl;
+
+import com.service.sport_companion.api.component.crawl.CrawlFixtures;
+import com.service.sport_companion.api.service.FixturesService;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.type.SuccessResultType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FixturesServiceImpl implements FixturesService {
+
+  private final CrawlFixtures crawlFixtures;
+
+  @Override
+  public ResultResponse crawlFixtures(String year) {
+    crawlFixtures.crawlFixtures(year);
+
+    return ResultResponse.of(SuccessResultType.SUCCESS_CRAWL_FIXTURE);
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
@@ -16,7 +16,7 @@ public class FixturesServiceImpl implements FixturesService {
   private final CrawlFixtures crawlFixtures;
 
   @Override
-  public ResultResponse crawlFixtures(String year) {
+  public ResultResponse<Void> crawlFixtures(String year) {
     crawlFixtures.crawlFixtures(year);
 
     return ResultResponse.of(SuccessResultType.SUCCESS_CRAWL_FIXTURE);

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/ClubsHandlerTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/ClubsHandlerTest.java
@@ -101,7 +101,7 @@ class ClubsHandlerTest {
   @DisplayName("구단 조회 성공")
   void shouldReturnClubsEntityByTeam() {
     // given
-    when(clubsRepository.findByFieldContaining(TEAM)).thenReturn(club);
+    when(clubsRepository.findByClubNameContaining(TEAM)).thenReturn(club);
 
     // when
     ClubsEntity response = clubsHandler.findByFieldContaining(TEAM);

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/ClubsHandlerTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/ClubsHandlerTest.java
@@ -27,6 +27,7 @@ class ClubsHandlerTest {
   private ClubsHandler clubsHandler;
 
   private final String CLUB_NAME = "KIA 타이거즈";
+  private final String TEAM = "KIA";
 
   private ClubsEntity club;
   private List<ClubsEntity> clubsEntities;
@@ -94,5 +95,18 @@ class ClubsHandlerTest {
 
     // then
     assertEquals(clubsList.size(), response.size());
+  }
+
+  @Test
+  @DisplayName("구단 조회 성공")
+  void shouldReturnClubsEntityByTeam() {
+    // given
+    when(clubsRepository.findByFieldContaining(TEAM)).thenReturn(club);
+
+    // when
+    ClubsEntity response = clubsHandler.findByFieldContaining(TEAM);
+
+    // then
+    assertEquals(response, club);
   }
 }

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/FixtureHandlerTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/FixtureHandlerTest.java
@@ -1,0 +1,81 @@
+package com.service.sport_companion.api.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.entity.FixturesEntity;
+import com.service.sport_companion.domain.entity.SeasonsEntity;
+import com.service.sport_companion.domain.repository.FixturesRepository;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FixtureHandlerTest {
+
+  @Mock
+  private FixturesRepository fixturesRepository;
+
+  @InjectMocks
+  private FixtureHandler fixtureHandler;
+
+  private List<FixturesEntity> fixturesList;
+
+  @BeforeEach
+  void setUp() {
+    ClubsEntity homeClub1 = ClubsEntity.builder().clubId(4L).clubName("Mock Home Club 1").build();
+    ClubsEntity awayClub1 = ClubsEntity.builder().clubId(10L).clubName("Mock Away Club 1").build();
+
+    ClubsEntity homeClub2 = ClubsEntity.builder().clubId(4L).clubName("Mock Home Club 2").build();
+    ClubsEntity awayClub2 = ClubsEntity.builder().clubId(10L).clubName("Mock Away Club 2").build();
+
+    SeasonsEntity season = SeasonsEntity.builder().seasonId(3L).seasonName("Mock Season").build();
+
+    fixturesList = List.of(
+        FixturesEntity.builder()
+            .fixtureId(4233L)
+            .fixtureDate(LocalDate.parse("2019-10-25"))
+            .fixtureTime("18:30")
+            .homeScore("5")
+            .awayScore("0")
+            .notes("-")
+            .stadium("고척")
+            .homeClub(homeClub1)
+            .awayClub(awayClub1)
+            .seasons(season)
+            .build(),
+        FixturesEntity.builder()
+            .fixtureId(4234L)
+            .fixtureDate(LocalDate.parse("2019-10-26"))
+            .fixtureTime("14:00")
+            .homeScore("11")
+            .awayScore("9")
+            .notes("-")
+            .stadium("고척")
+            .homeClub(homeClub2)
+            .awayClub(awayClub2)
+            .seasons(season)
+            .build()
+    );
+  }
+
+  @Test
+  @DisplayName("크롤링 정보 저장 성공")
+  void saveFixtureListSuccessfully() {
+    // given
+    when(fixturesRepository.saveAll(fixturesList)).thenReturn(fixturesList);
+
+    // when
+    List<FixturesEntity> response = fixturesRepository.saveAll(fixturesList);
+
+    // then
+    assertEquals(response, fixturesList);
+  }
+}

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/FixtureHandlerTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/FixtureHandlerTest.java
@@ -8,6 +8,7 @@ import com.service.sport_companion.domain.entity.FixturesEntity;
 import com.service.sport_companion.domain.entity.SeasonsEntity;
 import com.service.sport_companion.domain.repository.FixturesRepository;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -42,9 +43,9 @@ class FixtureHandlerTest {
         FixturesEntity.builder()
             .fixtureId(4233L)
             .fixtureDate(LocalDate.parse("2019-10-25"))
-            .fixtureTime("18:30")
-            .homeScore("5")
-            .awayScore("0")
+            .fixtureTime(LocalTime.parse("18:30"))
+            .homeScore(5)
+            .awayScore(0)
             .notes("-")
             .stadium("고척")
             .homeClub(homeClub1)
@@ -54,9 +55,9 @@ class FixtureHandlerTest {
         FixturesEntity.builder()
             .fixtureId(4234L)
             .fixtureDate(LocalDate.parse("2019-10-26"))
-            .fixtureTime("14:00")
-            .homeScore("11")
-            .awayScore("9")
+            .fixtureTime(LocalTime.parse("14:00"))
+            .homeScore(11)
+            .awayScore(0)
             .notes("-")
             .stadium("고척")
             .homeClub(homeClub2)

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/SeasonHandlerTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/SeasonHandlerTest.java
@@ -1,0 +1,50 @@
+package com.service.sport_companion.api.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.service.sport_companion.domain.entity.SeasonsEntity;
+import com.service.sport_companion.domain.repository.SeasonsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SeasonHandlerTest {
+
+  @Mock
+  private SeasonsRepository seasonsRepository;
+
+  @InjectMocks
+  private SeasonHandler seasonHandler;
+
+  private final String SEASON_NAME = "KBO 정규시즌 일정";
+
+  private SeasonsEntity seasons;
+
+  @BeforeEach
+  void setUp() {
+    seasons = SeasonsEntity.builder()
+        .seasonId(1L)
+        .seasonName(SEASON_NAME).build();
+
+  }
+
+  @Test
+  @DisplayName("시즌 정보 조회 성공")
+  void getSeasonsBySeasonName() {
+    // given
+    when(seasonsRepository.findBySeasonName(SEASON_NAME)).thenReturn(seasons);
+
+    // when
+    SeasonsEntity response = seasonHandler.findBySeasonName(SEASON_NAME);
+
+    // then
+    assertEquals(seasons, response);
+  }
+
+}

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/crawl/CrawlFixturesTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/component/crawl/CrawlFixturesTest.java
@@ -1,0 +1,124 @@
+package com.service.sport_companion.api.component.crawl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import com.service.sport_companion.api.component.ClubsHandler;
+import com.service.sport_companion.api.component.FixtureHandler;
+import com.service.sport_companion.api.component.SeasonHandler;
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.entity.FixturesEntity;
+import com.service.sport_companion.domain.entity.SeasonsEntity;
+import java.time.LocalDate;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class CrawlFixturesTest {
+
+  @Mock
+  private SeasonHandler seasonHandler;
+
+  @Mock
+  private ClubsHandler clubsHandler;
+
+  @Mock
+  private FixtureHandler fixtureHandler;
+
+  @InjectMocks
+  private CrawlFixtures crawlFixtures;
+
+  private SeasonsEntity mockedSeason;
+  private ClubsEntity mockedHomeClub;
+  private ClubsEntity mockedAwayClub;
+  private FixturesEntity fixtures;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    // Mocked data setup
+    mockedSeason = SeasonsEntity.builder()
+        .seasonId(1L)
+        .seasonName("KBO 정규시즌 일정")
+        .build();
+
+    mockedHomeClub = ClubsEntity.builder()
+        .clubId(1L)
+        .clubName("KT")
+        .build();
+
+    mockedAwayClub = ClubsEntity.builder()
+        .clubId(2L)
+        .clubName("두산")
+        .build();
+  }
+
+  @Test
+  void testParseToFixturesEntityWithSampleHtml() {
+    // Given
+    String year = "2024";
+    String lastDate = "10.02(수)";
+    String seriesKey = "KBO 정규시즌 일정";
+
+    String sampleHtml = """
+        <table>
+          <tbody>
+            <tr>
+              <td class="day" rowspan="1">10.02(수)</td>
+              <td class="time"><b>18:30</b></td>
+              <td class="play">
+                <span>KT</span>
+                <em>
+                  <span class="win">4</span>
+                  <span>vs</span>
+                  <span class="lose">0</span>
+                </em>
+                <span>두산</span>
+              </td>
+              <td class="relay">
+                <a>리뷰</a>
+              </td>
+              <td>
+                <a>
+              </td>
+              <td>K-2T</td>
+              <td></td>
+              <td>잠실</td>
+              <td>-</td>
+            </tr>
+          </tbody>
+        </table>
+    """;
+
+    Document doc = Jsoup.parse(sampleHtml);
+    Element schedule = doc.selectFirst("tr");
+
+    assertNotNull(schedule, "Parsed schedule is null. Check the provided HTML structure.");
+
+    // Mock dependencies
+    when(seasonHandler.findBySeasonName(seriesKey)).thenReturn(mockedSeason);
+    when(clubsHandler.findByFieldContaining("KT")).thenReturn(mockedHomeClub);
+    when(clubsHandler.findByFieldContaining("두산")).thenReturn(mockedAwayClub);
+
+    // When
+    FixturesEntity fixtures = crawlFixtures.parseToFixturesEntity(year, lastDate, schedule, seriesKey);
+
+    // Then
+    assertNotNull(fixtures, "Parsed fixtures is null.");
+    assertEquals(LocalDate.of(2024, 10, 2), fixtures.getFixtureDate());
+    assertEquals("18:30", fixtures.getFixtureTime());
+    assertEquals(mockedHomeClub, fixtures.getHomeClub());
+    assertEquals(mockedAwayClub, fixtures.getAwayClub());
+    assertEquals("4", fixtures.getHomeScore());
+    assertEquals("0", fixtures.getAwayScore());
+    assertEquals("잠실", fixtures.getStadium());
+    assertEquals("-", fixtures.getNotes());
+  }
+}

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/AuthServiceImplTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/AuthServiceImplTest.java
@@ -138,7 +138,7 @@ class AuthServiceImplTest {
     when(userHandler.getRandomNickname(1)).thenReturn(NICKNAME);
 
     // when
-    ResultResponse resultResponse = authServiceImpl.oAuthForKakao(CODE, response);
+    ResultResponse<?> resultResponse = authServiceImpl.oAuthForKakao(CODE, response);
 
     // then
     assertEquals(SuccessResultType.SUCCESS_SIGNUP_REQUIRED.getStatus(), resultResponse.getStatus());
@@ -157,7 +157,7 @@ class AuthServiceImplTest {
         .thenReturn(REFRESH_TOKEN);
 
     // when
-    ResultResponse resultResponse = authServiceImpl.oAuthForKakao(CODE, response);
+    ResultResponse<?> resultResponse = authServiceImpl.oAuthForKakao(CODE, response);
 
     // then
     assertEquals(SuccessResultType.SUCCESS_LOGIN.getStatus(), resultResponse.getStatus());
@@ -228,7 +228,7 @@ class AuthServiceImplTest {
     when(userHandler.existsByNickname(nickname)).thenReturn(!isValidNickname);
 
     // when
-    ResultResponse response = authServiceImpl.checkNickname(nickname);
+    ResultResponse<Boolean> response = authServiceImpl.checkNickname(nickname);
 
     // then
     assertEquals(response.getData(), isValidNickname);
@@ -246,7 +246,7 @@ class AuthServiceImplTest {
     when(userHandler.existsByNickname(nickname)).thenReturn(!isValidNickname);
 
     // when
-    ResultResponse response = authServiceImpl.checkNickname(nickname);
+    ResultResponse<Boolean> response = authServiceImpl.checkNickname(nickname);
 
     // then
     assertEquals(response.getData(), isValidNickname);
@@ -261,7 +261,7 @@ class AuthServiceImplTest {
     when(clubsHandler.findByClubName(signUpDto.getClubName())).thenReturn(club);
 
     // when
-    ResultResponse response = authServiceImpl.signup(signUpDto);
+    ResultResponse<Void> response = authServiceImpl.signup(signUpDto);
 
     // then
     assertEquals(SuccessResultType.SUCCESS_SIGNUP.getStatus(), response.getStatus());
@@ -294,7 +294,7 @@ class AuthServiceImplTest {
     when(jwtUtil.createJwt("access", user.getUserId(), user.getRole())).thenReturn(NEW_ACCESS_TOKEN);
 
     // when
-    ResultResponse resultResponse = authServiceImpl.reissueToken(request, response);
+    ResultResponse<Void> resultResponse = authServiceImpl.reissueToken(request, response);
 
     // then
     assertEquals(SuccessResultType.SUCCESS_REISSUE_TOKEN.getStatus(), resultResponse.getStatus());

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/ClubsServiceImplTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/ClubsServiceImplTest.java
@@ -68,7 +68,7 @@ class ClubsServiceImplTest {
     when(clubsHandler.getAllClubList()).thenReturn(clubsList);
 
     // when
-    ResultResponse resultResponse = clubsService.getAllClubList();
+    ResultResponse<List<Clubs>> resultResponse = clubsService.getAllClubList();
 
     // then
     assertEquals(SuccessResultType.SUCCESS_GET_ALL_CLUBS_LIST.getStatus(), resultResponse.getStatus());

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/FixturesServiceImplTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/FixturesServiceImplTest.java
@@ -32,7 +32,7 @@ class FixturesServiceImplTest {
     doNothing().when(crawlFixtures).crawlFixtures(YEAR);
 
     // when
-    ResultResponse resultResponse = fixturesService.crawlFixtures(YEAR);
+    ResultResponse<Void> resultResponse = fixturesService.crawlFixtures(YEAR);
 
     // then
     assertEquals(SuccessResultType.SUCCESS_CRAWL_FIXTURE.getStatus(), resultResponse.getStatus());

--- a/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/FixturesServiceImplTest.java
+++ b/sport_companion/module-api/src/test/java/com/service/sport_companion/api/service/impl/FixturesServiceImplTest.java
@@ -1,0 +1,41 @@
+package com.service.sport_companion.api.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import com.service.sport_companion.api.component.crawl.CrawlFixtures;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.type.SuccessResultType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FixturesServiceImplTest {
+
+  @Mock
+  private CrawlFixtures crawlFixtures;
+
+  @InjectMocks
+  private FixturesServiceImpl fixturesService;
+
+  private final String YEAR = "2024";
+
+  @Test
+  @DisplayName("년도 별 경기 일정 크롤링 성공")
+  void crawlFixturesSuccessfully() {
+    // given
+    doNothing().when(crawlFixtures).crawlFixtures(YEAR);
+
+    // when
+    ResultResponse resultResponse = fixturesService.crawlFixtures(YEAR);
+
+    // then
+    assertEquals(SuccessResultType.SUCCESS_CRAWL_FIXTURE.getStatus(), resultResponse.getStatus());
+  }
+
+}

--- a/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/config/NewsCrawlConfig.java
+++ b/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/config/NewsCrawlConfig.java
@@ -19,7 +19,7 @@ import org.springframework.orm.jpa.JpaTransactionManager;
 @Configuration
 @EnableBatchProcessing
 @RequiredArgsConstructor
-public class BatchConfig {
+public class NewsCrawlConfig {
 
   private final EntityManagerFactory entityManagerFactory;
   private final MbcNewsCrawling mbcNewsCrawling;

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/FixturesEntity.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/FixturesEntity.java
@@ -32,17 +32,17 @@ public class FixturesEntity {
   @JoinColumn(name = "home_club_id", nullable = false)
   private ClubsEntity homeClub;
 
-  private String homeScore;
+  private int homeScore;
 
   @ManyToOne
   @JoinColumn(name = "away_club_id", nullable = false)
   private ClubsEntity awayClub;
 
-  private String awayScore;
+  private int awayScore;
 
   private LocalDate fixtureDate;
 
-  private String fixtureTime;
+  private LocalTime fixtureTime;
 
   private String stadium;
 

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/FixturesEntity.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/FixturesEntity.java
@@ -25,16 +25,26 @@ public class FixturesEntity {
   private Long fixtureId;
 
   @ManyToOne
+  @JoinColumn(name = "season_id", nullable = false)
+  private SeasonsEntity seasons;
+
+  @ManyToOne
   @JoinColumn(name = "home_club_id", nullable = false)
   private ClubsEntity homeClub;
+
+  private String homeScore;
 
   @ManyToOne
   @JoinColumn(name = "away_club_id", nullable = false)
   private ClubsEntity awayClub;
 
+  private String awayScore;
+
   private LocalDate fixtureDate;
 
-  private LocalTime fixtureTime;
+  private String fixtureTime;
 
   private String stadium;
+
+  private String notes;
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/SeasonsEntity.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/SeasonsEntity.java
@@ -1,0 +1,25 @@
+package com.service.sport_companion.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "Seasons")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class SeasonsEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long seasonId;
+
+  private String seasonName;
+
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -19,6 +19,9 @@ public enum SuccessResultType {
   //Club
   SUCCESS_GET_ALL_CLUBS_LIST(HttpStatus.OK, "모든 구단 조회 성공!"),
 
+  // Fixtures
+  SUCCESS_CRAWL_FIXTURE(HttpStatus.OK, "크롤링 성공"),
+
   ;
 
   private final HttpStatus status;

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/ClubsRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/ClubsRepository.java
@@ -2,8 +2,6 @@ package com.service.sport_companion.domain.repository;
 
 import com.service.sport_companion.domain.entity.ClubsEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,6 +9,5 @@ public interface ClubsRepository extends JpaRepository<ClubsEntity, Long> {
 
   ClubsEntity findByClubName(String clubName);
 
-  @Query("SELECT c FROM Clubs c WHERE c.clubName LIKE %:team%")
-  ClubsEntity findByFieldContaining(@Param("team") String team);
+  ClubsEntity findByClubNameContaining(String team);
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/ClubsRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/ClubsRepository.java
@@ -2,10 +2,15 @@ package com.service.sport_companion.domain.repository;
 
 import com.service.sport_companion.domain.entity.ClubsEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClubsRepository extends JpaRepository<ClubsEntity, Long> {
 
   ClubsEntity findByClubName(String clubName);
+
+  @Query("SELECT c FROM Clubs c WHERE c.clubName LIKE %:team%")
+  ClubsEntity findByFieldContaining(@Param("team") String team);
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/SeasonsRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/SeasonsRepository.java
@@ -1,0 +1,12 @@
+package com.service.sport_companion.domain.repository;
+
+import com.service.sport_companion.domain.entity.SeasonsEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SeasonsRepository extends JpaRepository<SeasonsEntity, Long> {
+
+  SeasonsEntity findBySeasonName(String seasonName);
+
+}


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 경기 일정 크롤링 API 구현
   - 기획 파트 요청으로, 서비스 초기에는 매번 업데이트를 할 필요가 없기 때문에, API로 구현
   - 새로운 시즌이 시작 되면 그때, 다시 배치 작업으로 구현할 예정
   - 년도 입력시 해당 년도에 해당하는 모든 경기 일정 크롤링 후 DB에 저장 
 - ResultResponse 반환 타입 수정

## 스크린샷

## 주의사항

Closes #40 
