### PR TITLE
[feat] 주제(CustomTopic) 조회 API 구현

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicHandler.java
@@ -7,6 +7,8 @@ import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto
 import com.service.sport_companion.domain.model.type.FailedResultType;
 import com.service.sport_companion.domain.repository.CustomTopicRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -29,5 +31,9 @@ public class CustomTopicHandler {
 
   public void deleteTopic(Long topicId) {
     customTopicRepository.deleteById(topicId);
+  }
+
+  public Page<CustomTopicEntity> findTopicOrderByCreatedAt(Pageable pageable) {
+    return customTopicRepository.findAllByOrderByCreatedAtDesc(pageable);
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicHandler.java
@@ -6,6 +6,8 @@ import com.service.sport_companion.domain.entity.UsersEntity;
 import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto;
 import com.service.sport_companion.domain.model.type.FailedResultType;
 import com.service.sport_companion.domain.repository.CustomTopicRepository;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,5 +37,9 @@ public class CustomTopicHandler {
 
   public Page<CustomTopicEntity> findTopicOrderByCreatedAt(Pageable pageable) {
     return customTopicRepository.findAllByOrderByCreatedAtDesc(pageable);
+  }
+
+  public List<CustomTopicEntity> findTop5OrderByVoteCount(LocalDateTime createdAt) {
+    return customTopicRepository.findTop5ByCreatedAtAfterOrderByVoteCountDesc(createdAt);
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/CustomTopicController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/CustomTopicController.java
@@ -3,10 +3,14 @@ package com.service.sport_companion.api.controller;
 import com.service.sport_companion.api.service.CustomTopicService;
 import com.service.sport_companion.domain.model.annotation.CallUser;
 import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto;
+import com.service.sport_companion.domain.model.dto.response.PageResponse;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.topic.CustomTopicResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,6 +38,18 @@ public class CustomTopicController {
     @PathVariable("topicId") Long topicId
   ) {
     ResultResponse<Void> response = customTopicService.deleteTopic(userId, topicId);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  // 주제 최신순으로 조회
+  @GetMapping
+  public ResponseEntity<ResultResponse<PageResponse<CustomTopicResponse>>> getTopicList(
+    @CallUser Long userId,
+    Pageable pageable
+  ) {
+    ResultResponse<PageResponse<CustomTopicResponse>> response = customTopicService
+      .getTopicList(userId, pageable);
 
     return new ResponseEntity<>(response, response.getStatus());
   }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/CustomTopicController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/CustomTopicController.java
@@ -6,6 +6,7 @@ import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto
 import com.service.sport_companion.domain.model.dto.response.PageResponse;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import com.service.sport_companion.domain.model.dto.response.topic.CustomTopicResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -50,6 +51,16 @@ public class CustomTopicController {
   ) {
     ResultResponse<PageResponse<CustomTopicResponse>> response = customTopicService
       .getTopicList(userId, pageable);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  // 주제 top5 조회
+  @GetMapping("/top5")
+  public ResponseEntity<ResultResponse<List<CustomTopicResponse>>> getTopicTop5(
+    @CallUser Long userId
+  ) {
+    ResultResponse<List<CustomTopicResponse>> response = customTopicService.getTopicTop5(userId);
 
     return new ResponseEntity<>(response, response.getStatus());
   }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/CustomTopicService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/CustomTopicService.java
@@ -1,11 +1,16 @@
 package com.service.sport_companion.api.service;
 
 import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto;
+import com.service.sport_companion.domain.model.dto.response.PageResponse;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.topic.CustomTopicResponse;
+import org.springframework.data.domain.Pageable;
 
 public interface CustomTopicService {
 
   ResultResponse<Void> createTopic(Long userId, CreateTopicDto createTopicDto);
 
   ResultResponse<Void> deleteTopic(Long userId, Long topicId);
+
+  ResultResponse<PageResponse<CustomTopicResponse>> getTopicList(Long userId, Pageable pageable);
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/CustomTopicService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/CustomTopicService.java
@@ -4,6 +4,7 @@ import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto
 import com.service.sport_companion.domain.model.dto.response.PageResponse;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import com.service.sport_companion.domain.model.dto.response.topic.CustomTopicResponse;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomTopicService {
@@ -13,4 +14,6 @@ public interface CustomTopicService {
   ResultResponse<Void> deleteTopic(Long userId, Long topicId);
 
   ResultResponse<PageResponse<CustomTopicResponse>> getTopicList(Long userId, Pageable pageable);
+
+  ResultResponse<List<CustomTopicResponse>> getTopicTop5(Long userId);
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImpl.java
@@ -14,6 +14,8 @@ import com.service.sport_companion.domain.model.type.FailedResultType;
 import com.service.sport_companion.domain.model.type.SuccessResultType;
 import com.service.sport_companion.domain.model.type.UserRole;
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -73,6 +75,21 @@ public class CustomTopicServiceImpl implements CustomTopicService {
             isAuthor(userId, topic.getUsers().getUserId()))
           )
           .toList()));
+  }
+
+  @Override
+  public ResultResponse<List<CustomTopicResponse>> getTopicTop5(Long userId) {
+    // 일주일 간 올라온 토픽 중 top5를 선정하기 위해 7일 전 날짜 저장
+    LocalDateTime before7Days = LocalDateTime.now().minusDays(7);
+
+    List<CustomTopicEntity> topicPage = customTopicHandler.findTop5OrderByVoteCount(before7Days);
+
+    return new ResultResponse<>(SuccessResultType.SUCCESS_GET_CUSTOM_TOPIC, topicPage.stream()
+      .map(topic -> CustomTopicResponse.of(
+        topic,
+        isAuthor(userId, topic.getUsers().getUserId()))
+      )
+      .toList());
   }
 
   private boolean isAuthor(Long userId, Long authorId) {

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/topic/CustomTopicResponse.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/topic/CustomTopicResponse.java
@@ -1,0 +1,37 @@
+package com.service.sport_companion.domain.model.dto.response.topic;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.service.sport_companion.domain.entity.CustomTopicEntity;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomTopicResponse {
+
+  private Long topicId;
+
+  private String topic;
+
+  private Long recommendCount;
+
+  @JsonFormat(pattern = "yyyy-MM-dd hh:mm", timezone = "Asia/seoul")
+  private LocalDateTime createdAt;
+
+  private boolean isAuthor;
+
+  public static CustomTopicResponse of(CustomTopicEntity customTopicEntity, boolean isAuthor) {
+    return CustomTopicResponse.builder()
+      .topicId(customTopicEntity.getCustomTopicId())
+      .topic(customTopicEntity.getTopic())
+      .recommendCount(customTopicEntity.getVoteCount())
+      .createdAt(customTopicEntity.getCreatedAt())
+      .isAuthor(isAuthor)
+      .build();
+  }
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -25,6 +25,7 @@ public enum SuccessResultType {
   // CustomTopic
   SUCCESS_CREATE_CUSTOM_TOPIC(HttpStatus.CREATED, "주제가 작성되었습니다."),
   SUCCESS_DELETE_CUSTOM_TOPIC(HttpStatus.OK, "주제가 삭제되었습니다"),
+  SUCCESS_GET_CUSTOM_TOPIC(HttpStatus.OK, "주제를 성공적으로 조회했습니다.")
 
   ;
 

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRepository.java
@@ -1,6 +1,8 @@
 package com.service.sport_companion.domain.repository;
 
 import com.service.sport_companion.domain.entity.CustomTopicEntity;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface CustomTopicRepository extends JpaRepository<CustomTopicEntity, Long> {
 
   Page<CustomTopicEntity> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+  List<CustomTopicEntity> findTop5ByCreatedAtAfterOrderByVoteCountDesc(LocalDateTime createdAt);
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRepository.java
@@ -1,10 +1,13 @@
 package com.service.sport_companion.domain.repository;
 
 import com.service.sport_companion.domain.entity.CustomTopicEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CustomTopicRepository extends JpaRepository<CustomTopicEntity, Long> {
 
+  Page<CustomTopicEntity> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
**CustomTopicController**
- 주제 조회 API 2개 구현 (전체, top5)

**CustomTopicService(Impl)**
- 주제를 페이징 처리하여 최신순으로 조회하는 메서드 구현
- 주제를 최근 7일중 가장 추천수가 높은순으로 5개 조회하는 메서드 구현

**CustomTopicHandler**
- CustomTopicRepository를 이용해 CustomTopic 엔티티 조회

**CustomTopicResponse**
- API에 반환할 응답값 생성
  - isAuthor : 주제의 본인 작성 여부값
  - createdAt : JsonFormat을 통해 2024-11-30 22:00 형식으로 출력하며, 한국 시간 기준으로 반환

## 스크린샷

## 주의사항

Closes #53
