### PR TITLE
[feat] 경기 일정 조회 API 구현

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtFilter.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtFilter.java
@@ -95,9 +95,24 @@ public class JwtFilter extends OncePerRequestFilter {
       return true;
     }
 
-    log.info("method >>> {} request uri >>> {}", method, path);
+    log.info("request uri >>> {}", path);
     // 2. 예외 경로 검증
-    return isExcludedPath(pathMatcher, path);
+    if (isExcludedPath(pathMatcher, path)) {
+      return true;
+    }
+
+    // 3. 요청 메서드 검증
+    if ("GET".equalsIgnoreCase(method)) {
+
+      // 4. 토큰 검증
+      if (request.getHeader(TokenType.ACCESS.getValue()) == null) {
+
+        // 5. 비 로그인 사용자 요청 경로 검증
+        return isMatchingGetRequest(pathMatcher, path);
+      }
+    }
+
+    return false;
   }
 
   // Jwt 검증 제외 경로
@@ -112,5 +127,10 @@ public class JwtFilter extends OncePerRequestFilter {
         || pathMatcher.match("/swagger-ui/**", requestURI)
         || pathMatcher.match("/swagger-ui.html", requestURI)
         || pathMatcher.match("/swagger-resources/**", requestURI);
+  }
+
+  public boolean isMatchingGetRequest(AntPathMatcher pathMatcher, String requestURI) {
+
+    return pathMatcher.match("/api/v1/fixture", requestURI);
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/FixtureHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/FixtureHandler.java
@@ -1,7 +1,14 @@
 package com.service.sport_companion.api.component;
 
+import com.service.sport_companion.core.exception.GlobalException;
+import com.service.sport_companion.domain.entity.ClubsEntity;
 import com.service.sport_companion.domain.entity.FixturesEntity;
+import com.service.sport_companion.domain.entity.SeasonsEntity;
+import com.service.sport_companion.domain.model.dto.response.fixtures.Fixtures;
+import com.service.sport_companion.domain.model.type.FailedResultType;
 import com.service.sport_companion.domain.repository.FixturesRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -15,5 +22,28 @@ public class FixtureHandler {
 
   public void saveFixtureList(List<FixturesEntity> fixturesList) {
     fixturesRepository.saveAll(fixturesList);
+  }
+
+  public List<Fixtures> getAllFixturesList(LocalDate fixtureDate, SeasonsEntity seasons) {
+    return mapToFixturesList(fixturesRepository.findAllByFixtureDateAndSeasons(fixtureDate, seasons));
+  }
+
+  public List<Fixtures> getSupportClubFixturesList(LocalDate fixtureDate, SeasonsEntity seasons, ClubsEntity clubs) {
+    return mapToFixturesList(fixturesRepository.findSupportFixtures(fixtureDate, seasons, clubs));
+  }
+
+  private List<Fixtures> mapToFixturesList(List<FixturesEntity> fixturesEntities) {
+    return fixturesEntities.stream()
+        .map(fixture -> new Fixtures(
+            fixture.getFixtureDate(),
+            fixture.getFixtureTime(),
+            fixture.getHomeClub().getClubName(),
+            fixture.getHomeScore(),
+            fixture.getAwayClub().getClubName(),
+            fixture.getAwayScore(),
+            fixture.getStadium(),
+            fixture.getNotes()
+        ))
+        .toList();
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/SupportedClubsHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/SupportedClubsHandler.java
@@ -1,5 +1,6 @@
 package com.service.sport_companion.api.component;
 
+import com.service.sport_companion.domain.entity.ClubsEntity;
 import com.service.sport_companion.domain.entity.SupportedClubsEntity;
 import com.service.sport_companion.domain.repository.SupportedClubsRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,5 +14,11 @@ public class SupportedClubsHandler {
 
   public void saveSupportedClub(SupportedClubsEntity supportedClub) {
     supportedClubsRepository.save(supportedClub);
+  }
+
+  public ClubsEntity findSupportClubsByUserId(Long userId) {
+    return supportedClubsRepository.findByUserUserId(userId)
+        .map(SupportedClubsEntity::getClub)
+        .orElse(new ClubsEntity());
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/crawl/CrawlFixtures.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/crawl/CrawlFixtures.java
@@ -145,7 +145,7 @@ public class CrawlFixtures {
     }
 
     // 점수를 가져오거나 "-"로 설정
-    int homeScore = (homeScoreElement != null) ? Integer.parseInt(awayScoreElement.text()) : 0;
+    int homeScore = (homeScoreElement != null) ? Integer.parseInt(homeScoreElement.text()) : 0;
     int awayScore = (awayScoreElement != null) ? Integer.parseInt(awayScoreElement.text()) : 0;
 
     // 경기장 및 비고

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -51,6 +52,8 @@ public class SecurityConfig {
                 "/api/v1/clubs/all",
                 "/api/v1/fixture/crawl",
                 "/favicon.ico").permitAll()
+            .requestMatchers(HttpMethod.GET,
+                "/api/v1/fixture").permitAll()
             .anyRequest().authenticated());
 
     http

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/FixturesController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/FixturesController.java
@@ -1,7 +1,10 @@
 package com.service.sport_companion.api.controller;
 
 import com.service.sport_companion.api.service.FixturesService;
+import com.service.sport_companion.domain.model.annotation.CallUser;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.fixtures.Fixtures;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,11 +21,25 @@ public class FixturesController {
 
   // 추후 변경할 예정
   @GetMapping("/crawl")
-  private ResponseEntity<ResultResponse<Void>> crawlFixtures(@RequestParam("year") String year) {
+  public ResponseEntity<ResultResponse<Void>> crawlFixtures(@RequestParam("year") String year) {
 
     ResultResponse<Void> response = fixturesService.crawlFixtures(year);
     return new ResponseEntity<>(response, response.getStatus());
 
+  }
+
+  @GetMapping
+  public ResponseEntity<ResultResponse<List<Fixtures>>> getFixtureList(
+      @CallUser Long userId,
+      @RequestParam("year") String year,
+      @RequestParam("month") String month,
+      @RequestParam("day") String day,
+      @RequestParam("season") String season) {
+
+    ResultResponse<List<Fixtures>> response = fixturesService
+        .getFixtureList(userId, year, month, day, season);
+
+    return new ResponseEntity<>(response, response.getStatus());
   }
 
 

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/FixturesService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/FixturesService.java
@@ -1,8 +1,13 @@
 package com.service.sport_companion.api.service;
 
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.fixtures.Fixtures;
+import java.util.List;
 
 public interface FixturesService {
 
   ResultResponse<Void> crawlFixtures(String year);
+
+  ResultResponse<List<Fixtures>> getFixtureList(Long userId, String year, String month, String day,
+      String season);
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
@@ -1,9 +1,20 @@
 package com.service.sport_companion.api.service.impl;
 
+import com.service.sport_companion.api.component.FixtureHandler;
+import com.service.sport_companion.api.component.SeasonHandler;
+import com.service.sport_companion.api.component.SupportedClubsHandler;
 import com.service.sport_companion.api.component.crawl.CrawlFixtures;
 import com.service.sport_companion.api.service.FixturesService;
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.entity.FixturesEntity;
+import com.service.sport_companion.domain.entity.SeasonsEntity;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.fixtures.Fixtures;
 import com.service.sport_companion.domain.model.type.SuccessResultType;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,11 +25,32 @@ import org.springframework.stereotype.Service;
 public class FixturesServiceImpl implements FixturesService {
 
   private final CrawlFixtures crawlFixtures;
+  private final FixtureHandler fixtureHandler;
+  private final SeasonHandler seasonHandler;
+  private final SupportedClubsHandler supportedClubsHandler;
 
   @Override
   public ResultResponse<Void> crawlFixtures(String year) {
     crawlFixtures.crawlFixtures(year);
 
     return ResultResponse.of(SuccessResultType.SUCCESS_CRAWL_FIXTURE);
+  }
+
+  @Override
+  public ResultResponse<List<Fixtures>> getFixtureList(Long userId, String year, String month, String day, String seasonName) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    String formattedDate = year + "-" + month + "-" + day;
+    LocalDate fixtureDate = LocalDate.parse(formattedDate, formatter);
+
+    SeasonsEntity seasons = seasonHandler.findBySeasonName(seasonName);
+
+    ClubsEntity clubs = (userId != null) ? supportedClubsHandler.findSupportClubsByUserId(userId) : null;
+
+    // 필요한 데이터를 가져오기
+    List<Fixtures> fixturesList = (clubs != null)
+        ? fixtureHandler.getSupportClubFixturesList(fixtureDate, seasons, clubs)
+        : fixtureHandler.getAllFixturesList(fixtureDate, seasons);
+
+    return new ResultResponse<>(SuccessResultType.SUCCESS_GET_ALL_FIXTURES, fixturesList);
   }
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/fixtures/Fixtures.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/fixtures/Fixtures.java
@@ -1,0 +1,27 @@
+package com.service.sport_companion.domain.model.dto.response.fixtures;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Fixtures {
+
+  private LocalDate fixtureDate;
+
+  private LocalTime fixtureTime;
+
+  private String homeClubName;
+
+  private int homeScore;
+
+  private String awayClubName;
+
+  private int awayScore;
+
+  private String stadium;
+
+  private String notes;
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
@@ -28,6 +28,9 @@ public enum FailedResultType {
   // CustomTopic
   CUSTOM_TOPIC_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 주제입니다."),
   DELETE_TOPIC_FORBIDDEN(HttpStatus.FORBIDDEN, "주제 삭제 권한이 없습니다"),
+
+  // Fixture
+  FIXTURE_NOT_FOUND(HttpStatus.BAD_REQUEST, "데이터가 없습니다."),
   ;
 
   private final HttpStatus status;

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -24,6 +24,7 @@ public enum SuccessResultType {
 
   // Fixtures
   SUCCESS_CRAWL_FIXTURE(HttpStatus.OK, "크롤링 성공"),
+  SUCCESS_GET_ALL_FIXTURES(HttpStatus.OK, "모든 경기 일정 조회 성공"),
 
   // CustomTopic
   SUCCESS_CREATE_CUSTOM_TOPIC(HttpStatus.CREATED, "주제가 작성되었습니다."),

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/FixturesRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/FixturesRepository.java
@@ -1,10 +1,29 @@
 package com.service.sport_companion.domain.repository;
 
+import com.service.sport_companion.domain.entity.ClubsEntity;
 import com.service.sport_companion.domain.entity.FixturesEntity;
+import com.service.sport_companion.domain.entity.SeasonsEntity;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FixturesRepository extends JpaRepository<FixturesEntity, Long> {
+
+  List<FixturesEntity> findAllByFixtureDateAndSeasons(LocalDate fixtureDate,
+      SeasonsEntity seasons);
+
+  @Query("SELECT f FROM Fixtures f "
+      + "WHERE f.fixtureDate = :fixtureDate "
+      + "AND f.seasons = :seasons "
+      + "AND (f.homeClub = :clubs OR f.awayClub = :clubs)")
+  List<FixturesEntity> findSupportFixtures(@Param("fixtureDate") LocalDate fixtureDate,
+      @Param("seasons") SeasonsEntity seasons,
+      @Param("clubs") ClubsEntity clubs);
+
 
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/SupportedClubsRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/SupportedClubsRepository.java
@@ -1,10 +1,13 @@
 package com.service.sport_companion.domain.repository;
 
 import com.service.sport_companion.domain.entity.SupportedClubsEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SupportedClubsRepository extends JpaRepository<SupportedClubsEntity, Long> {
+
+  Optional<SupportedClubsEntity> findByUserUserId(Long userId);
 
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
경기 일정 조회 API

- FixturesController
   - 시즌, 년도, 월, 일을 전달 받아 해당 시즌 날짜와 일치 하는 경기 일정 조회
   
- FixtureService & FixturesServiceImpl
  - 비 로그인 사용자
    - 모든 구단의 일정 출력
  - 로그인 사용자
    - 선호 구단 미 등록 사용자
        - 모든 구단의 일정 출력
    - 선호 구단 등록 사용자
        - 선호 구단의 일정 출력     

- FixturesHandler
   - 시즌, 날짜에 해당 하는 모든 구단 일정 반환
   - 시즌, 날짜, 선호 구단에 해당 하는 모든 구단 일정 반환

- SesaonHandler
   - 시즌과 일치하는 SeasonEntity 반환

- SupportClubsHandler
   - 사용자ID와 일치하는 ClubsEntity 반환   
 

## 스크린샷

## 주의사항

Closes #55 
