### PR TITLE
[feat] 주제(CustomTopic) 추천 API 구현

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicRecommendHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicRecommendHandler.java
@@ -1,0 +1,34 @@
+package com.service.sport_companion.api.component;
+
+import com.service.sport_companion.domain.model.type.RedisKeyType;
+import com.service.sport_companion.domain.repository.CustomTopicRecommendRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomTopicRecommendHandler {
+
+  private final CustomTopicRecommendRepository customTopicRecommendRepository;
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  // topicId의 주제에 userId 사용자가 추천한 적 있는지 조회
+  public boolean existsTopicRecommend(Long userId, Long topicId) {
+    return customTopicRecommendRepository
+      .existsByCustomTopic_CustomTopicIdAndUsersEntity_UserId(topicId, userId);
+  }
+
+  // 사용자 주제 추천 기록 저장
+  public void saveByUserIdAndTopicId(Long userId, Long topicId) {
+    customTopicRecommendRepository.saveByUserIdAndTopicId(userId, topicId);
+  }
+
+  // (Redis) 주제 추천수를 1 증가한다.
+  public Long updateTopicRecommendAdd1(Long topicId) {
+    return redisTemplate.opsForValue().increment(
+      RedisKeyType.TOPIC_RECOMMEND.getKey() + topicId.toString());
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/CustomTopicController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/CustomTopicController.java
@@ -6,6 +6,7 @@ import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto
 import com.service.sport_companion.domain.model.dto.response.PageResponse;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import com.service.sport_companion.domain.model.dto.response.topic.CustomTopicResponse;
+import com.service.sport_companion.domain.model.dto.response.topic.RecommendCountResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -61,6 +62,18 @@ public class CustomTopicController {
     @CallUser Long userId
   ) {
     ResultResponse<List<CustomTopicResponse>> response = customTopicService.getTopicTop5(userId);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  // 주체 추천
+  @PostMapping("/{topicId}/recommend")
+  public ResponseEntity<ResultResponse<RecommendCountResponse>> recommendTopic(
+    @CallUser Long userId,
+    @PathVariable("topicId") Long topicId
+  ) {
+    ResultResponse<RecommendCountResponse> response =
+      customTopicService.updateTopicRecommend(userId, topicId);
 
     return new ResponseEntity<>(response, response.getStatus());
   }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/CustomTopicService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/CustomTopicService.java
@@ -4,6 +4,7 @@ import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto
 import com.service.sport_companion.domain.model.dto.response.PageResponse;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import com.service.sport_companion.domain.model.dto.response.topic.CustomTopicResponse;
+import com.service.sport_companion.domain.model.dto.response.topic.RecommendCountResponse;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 
@@ -16,4 +17,6 @@ public interface CustomTopicService {
   ResultResponse<PageResponse<CustomTopicResponse>> getTopicList(Long userId, Pageable pageable);
 
   ResultResponse<List<CustomTopicResponse>> getTopicTop5(Long userId);
+
+  ResultResponse<RecommendCountResponse> updateTopicRecommend(Long userId, Long topicId);
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/CustomTopicRecommendEntity.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/CustomTopicRecommendEntity.java
@@ -1,0 +1,34 @@
+package com.service.sport_companion.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "custom_topic_recommend")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CustomTopicRecommendEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long customTopicRecommendId;
+
+  @ManyToOne
+  @JoinColumn(name = "custom_topic_id", nullable = false)
+  private CustomTopicEntity customTopic;
+
+  @ManyToOne
+  @JoinColumn(name = "users_id", nullable = false)
+  private UsersEntity usersEntity;
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/topic/RecommendCountResponse.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/topic/RecommendCountResponse.java
@@ -1,0 +1,11 @@
+package com.service.sport_companion.domain.model.dto.response.topic;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RecommendCountResponse {
+
+  private Long recommendCount;
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
@@ -28,6 +28,7 @@ public enum FailedResultType {
   // CustomTopic
   CUSTOM_TOPIC_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 주제입니다."),
   DELETE_TOPIC_FORBIDDEN(HttpStatus.FORBIDDEN, "주제 삭제 권한이 없습니다"),
+  ALREADY_RECOMMEND_TOPIC(HttpStatus.BAD_REQUEST, "이미 추천한 주제입니다."),
   ;
 
   private final HttpStatus status;

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/RedisKeyType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/RedisKeyType.java
@@ -1,0 +1,13 @@
+package com.service.sport_companion.domain.model.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum RedisKeyType {
+  TOPIC_RECOMMEND("topicRecommend:")
+  ;
+
+  private final String key;
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -28,7 +28,8 @@ public enum SuccessResultType {
   // CustomTopic
   SUCCESS_CREATE_CUSTOM_TOPIC(HttpStatus.CREATED, "주제가 작성되었습니다."),
   SUCCESS_DELETE_CUSTOM_TOPIC(HttpStatus.OK, "주제가 삭제되었습니다"),
-  SUCCESS_GET_CUSTOM_TOPIC(HttpStatus.OK, "주제를 성공적으로 조회했습니다.")
+  SUCCESS_GET_CUSTOM_TOPIC(HttpStatus.OK, "주제를 성공적으로 조회했습니다."),
+  SUCCESS_RECOMMEND_TOPIC(HttpStatus.OK, "주제를 추천했습니다."),
 
   ;
 

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRecommendRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRecommendRepository.java
@@ -2,9 +2,19 @@ package com.service.sport_companion.domain.repository;
 
 import com.service.sport_companion.domain.entity.CustomTopicRecommendEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CustomTopicRecommendRepository extends JpaRepository<CustomTopicRecommendEntity, Long> {
 
+  boolean existsByCustomTopic_CustomTopicIdAndUsersEntity_UserId(Long customTopicId, Long usersId);
+
+  @Modifying
+  @Query(value = "INSERT "
+    + "INTO custom_topic_recommend(users_id, custom_topic_id) "
+    + "VALUES(:userId, :topicId)", nativeQuery = true)
+  void saveByUserIdAndTopicId(@Param("userId") Long userId, @Param("topicId") Long topicId);
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRecommendRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRecommendRepository.java
@@ -1,0 +1,10 @@
+package com.service.sport_companion.domain.repository;
+
+import com.service.sport_companion.domain.entity.CustomTopicRecommendEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomTopicRecommendRepository extends JpaRepository<CustomTopicRecommendEntity, Long> {
+
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
**CustomTopicRecommendEntity/Repository**
- 사용자가 주제를 추천했는지 조회할 수 있는 Entity, Repository 생성
- saveByUserIdAndTopicId : 추가적인 Entity조회를 하지 않기 위해 직접 id를 사용하는 insert (nativeQuery) 쿼리 구현

**CustomTopicRecommendService(Impl)**
- 사용자가 주제를 추천하면 아래 로직을 수행한다
  1. 사용자가 이미 추천한 적 있으면 throw exception
  2. CustomTopicRecommendEntity에 추천 내역을 업데이트
  3. redis를 통해 추천값을 업데이트하고 업데이트 된 값을 반환
* redis를 사용하는 이유 : 원자성 명령어인 INCR를 사용하여 동시성 문제를 방지하고 빠른 값 변경을 가능하게 한다.

**CustomTopicRecommendHandler**
- Service에서 필요한 추천 기록 조회, 추천 내역 업데이트, redis 추천값+1 메서드 구현

**RedisType**
- Redis Key로 사용할 이름을 Enum으로 정의

## 스크린샷

## 주의사항

Closes #58
