### PR TITLE
[fix] 주제 추천수 조회 방식 수정

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicHandler.java
@@ -4,6 +4,7 @@ import com.service.sport_companion.core.exception.GlobalException;
 import com.service.sport_companion.domain.entity.CustomTopicEntity;
 import com.service.sport_companion.domain.entity.UsersEntity;
 import com.service.sport_companion.domain.model.dto.request.topic.CreateTopicDto;
+import com.service.sport_companion.domain.model.dto.response.topic.TopicAndRecommendDto;
 import com.service.sport_companion.domain.model.type.FailedResultType;
 import com.service.sport_companion.domain.repository.CustomTopicRepository;
 import java.time.LocalDateTime;
@@ -35,11 +36,11 @@ public class CustomTopicHandler {
     customTopicRepository.deleteById(topicId);
   }
 
-  public Page<CustomTopicEntity> findTopicOrderByCreatedAt(Pageable pageable) {
+  public Page<TopicAndRecommendDto> findTopicOrderByCreatedAt(Pageable pageable) {
     return customTopicRepository.findAllByOrderByCreatedAtDesc(pageable);
   }
 
-  public List<CustomTopicEntity> findTop5OrderByVoteCount(LocalDateTime createdAt) {
+  public List<TopicAndRecommendDto> findTop5OrderByVoteCount(LocalDateTime createdAt) {
     return customTopicRepository.findTop5ByCreatedAtAfterOrderByVoteCountDesc(createdAt);
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicRecommendHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CustomTopicRecommendHandler.java
@@ -1,10 +1,8 @@
 package com.service.sport_companion.api.component;
 
-import com.service.sport_companion.domain.model.type.RedisKeyType;
 import com.service.sport_companion.domain.repository.CustomTopicRecommendRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -13,7 +11,6 @@ import org.springframework.stereotype.Component;
 public class CustomTopicRecommendHandler {
 
   private final CustomTopicRecommendRepository customTopicRecommendRepository;
-  private final RedisTemplate<String, Object> redisTemplate;
 
   // topicId의 주제에 userId 사용자가 추천한 적 있는지 조회
   public boolean existsTopicRecommend(Long userId, Long topicId) {
@@ -26,9 +23,8 @@ public class CustomTopicRecommendHandler {
     customTopicRecommendRepository.saveByUserIdAndTopicId(userId, topicId);
   }
 
-  // (Redis) 주제 추천수를 1 증가한다.
-  public Long updateTopicRecommendAdd1(Long topicId) {
-    return redisTemplate.opsForValue().increment(
-      RedisKeyType.TOPIC_RECOMMEND.getKey() + topicId.toString());
+  // topicId의 추천수를 조회한다.
+  public Long getRecommendCount(Long topicId) {
+    return customTopicRecommendRepository.countByCustomTopic_CustomTopicId(topicId);
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImpl.java
@@ -12,6 +12,7 @@ import com.service.sport_companion.domain.model.dto.response.PageResponse;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import com.service.sport_companion.domain.model.dto.response.topic.CustomTopicResponse;
 import com.service.sport_companion.domain.model.dto.response.topic.RecommendCountResponse;
+import com.service.sport_companion.domain.model.dto.response.topic.TopicAndRecommendDto;
 import com.service.sport_companion.domain.model.type.FailedResultType;
 import com.service.sport_companion.domain.model.type.SuccessResultType;
 import com.service.sport_companion.domain.model.type.UserRole;
@@ -65,7 +66,7 @@ public class CustomTopicServiceImpl implements CustomTopicService {
       pageable = Pageable.unpaged();
     }
 
-    Page<CustomTopicEntity> topicPage = customTopicHandler.findTopicOrderByCreatedAt(pageable);
+    Page<TopicAndRecommendDto> topicPage = customTopicHandler.findTopicOrderByCreatedAt(pageable);
 
     return new ResultResponse<>(SuccessResultType.SUCCESS_GET_CUSTOM_TOPIC,
       new PageResponse<>(
@@ -74,8 +75,9 @@ public class CustomTopicServiceImpl implements CustomTopicService {
         topicPage.getTotalElements(),
         topicPage.getContent().stream()
           .map(topic -> CustomTopicResponse.of(
-            topic,
-            isAuthor(userId, topic.getUsers().getUserId()))
+            topic.getCustomTopicEntity(),
+            isAuthor(userId, topic.getCustomTopicEntity().getUsers().getUserId()),
+            topic.getRecommendCount())
           )
           .toList()));
   }
@@ -85,12 +87,13 @@ public class CustomTopicServiceImpl implements CustomTopicService {
     // 일주일 간 올라온 토픽 중 top5를 선정하기 위해 7일 전 날짜 저장
     LocalDateTime before7Days = LocalDateTime.now().minusDays(7);
 
-    List<CustomTopicEntity> topicPage = customTopicHandler.findTop5OrderByVoteCount(before7Days);
+    List<TopicAndRecommendDto> topicPage = customTopicHandler.findTop5OrderByVoteCount(before7Days);
 
     return new ResultResponse<>(SuccessResultType.SUCCESS_GET_CUSTOM_TOPIC, topicPage.stream()
       .map(topic -> CustomTopicResponse.of(
-        topic,
-        isAuthor(userId, topic.getUsers().getUserId()))
+        topic.getCustomTopicEntity(),
+        isAuthor(userId, topic.getCustomTopicEntity().getUsers().getUserId()),
+        topic.getRecommendCount())
       )
       .toList());
   }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImpl.java
@@ -107,9 +107,9 @@ public class CustomTopicServiceImpl implements CustomTopicService {
     // 사용자 추천 내역을 DB에 추가
     customTopicRecommendHandler.saveByUserIdAndTopicId(userId, topicId);
 
-    // 추천값을 +1 하고 업데이트된 값 반환
+    // 현재 추천수 반환
     return new ResultResponse<>(SuccessResultType.SUCCESS_RECOMMEND_TOPIC,
-      new RecommendCountResponse(customTopicRecommendHandler.updateTopicRecommendAdd1(topicId)));
+      new RecommendCountResponse(customTopicRecommendHandler.getRecommendCount(topicId)));
   }
 
   private boolean isAuthor(Long userId, Long authorId) {

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/topic/CustomTopicResponse.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/topic/CustomTopicResponse.java
@@ -25,11 +25,11 @@ public class CustomTopicResponse {
 
   private boolean isAuthor;
 
-  public static CustomTopicResponse of(CustomTopicEntity customTopicEntity, boolean isAuthor) {
+  public static CustomTopicResponse of(CustomTopicEntity customTopicEntity, boolean isAuthor, Long recommendCount) {
     return CustomTopicResponse.builder()
       .topicId(customTopicEntity.getCustomTopicId())
       .topic(customTopicEntity.getTopic())
-      .recommendCount(customTopicEntity.getVoteCount())
+      .recommendCount(recommendCount)
       .createdAt(customTopicEntity.getCreatedAt())
       .isAuthor(isAuthor)
       .build();

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/topic/TopicAndRecommendDto.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/topic/TopicAndRecommendDto.java
@@ -1,0 +1,13 @@
+package com.service.sport_companion.domain.model.dto.response.topic;
+
+import com.service.sport_companion.domain.entity.CustomTopicEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TopicAndRecommendDto {
+
+  private CustomTopicEntity customTopicEntity;
+  private Long recommendCount;
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRecommendRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRecommendRepository.java
@@ -17,4 +17,6 @@ public interface CustomTopicRecommendRepository extends JpaRepository<CustomTopi
     + "INTO custom_topic_recommend(users_id, custom_topic_id) "
     + "VALUES(:userId, :topicId)", nativeQuery = true)
   void saveByUserIdAndTopicId(@Param("userId") Long userId, @Param("topicId") Long topicId);
+
+  Long countByCustomTopic_CustomTopicId(Long topicId);
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CustomTopicRepository.java
@@ -1,17 +1,33 @@
 package com.service.sport_companion.domain.repository;
 
 import com.service.sport_companion.domain.entity.CustomTopicEntity;
+import com.service.sport_companion.domain.model.dto.response.topic.TopicAndRecommendDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CustomTopicRepository extends JpaRepository<CustomTopicEntity, Long> {
 
-  Page<CustomTopicEntity> findAllByOrderByCreatedAtDesc(Pageable pageable);
+  @Query("SELECT new com.service.sport_companion.domain.model.dto.response.topic.TopicAndRecommendDto(c, COUNT(r)) "
+    + "FROM CustomTopicEntity c "
+    + "LEFT JOIN CustomTopicRecommendEntity r ON c = r.customTopic "
+    + "GROUP BY c "
+    + "ORDER BY c.createdAt DESC ")
+  Page<TopicAndRecommendDto> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
-  List<CustomTopicEntity> findTop5ByCreatedAtAfterOrderByVoteCountDesc(LocalDateTime createdAt);
+  @Query("SELECT new com.service.sport_companion.domain.model.dto.response.topic.TopicAndRecommendDto(c, COUNT(r)) "
+    + "FROM CustomTopicEntity c "
+    + "LEFT JOIN CustomTopicRecommendEntity r ON c = r.customTopic "
+    + "WHERE c.createdAt > :createdAt "
+    + "GROUP BY c "
+    + "ORDER BY COUNT(r) DESC "
+    + "LIMIT 5")
+  List<TopicAndRecommendDto> findTop5ByCreatedAtAfterOrderByVoteCountDesc(
+    @Param("createdAt") LocalDateTime createdAt);
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
**TopicAndRecommendDto**
- Repository Query에서 Entity와 추천수(Count(*))를 바로 가져오도록 DTO를 생성하여 사용

**CustomTopicResponse.of**
- 추천수 값을 엔티티에서 가져오지 않고, 파라미터로 입력받아서 사용

**CustomTopicService**
- 조회 시 CustomTopicRecommend에서 가져오면서 Redis 사용 이유가 없어져서 추천 로직 수정

**CustomTopicRepository**
- 사용자 추천 내역을 저장하는 테이블(CustomTopicRecommend)에서 topicId로 등록된 추천수의 갯수로 추천수를 조회
  - 양방향 매핑으로 연결 후, List.size()로 조회하는 방식을 생각했으나 추천수가 크면 모든 데이터를 가지고 오는 것이 부담될 수 있으므로 X
  - DB 조회 시 한번에 가져올 수 있으므로 Redis에 저장된 값을 가져오는 방식은 

## 스크린샷

## 주의사항
- 추후 QueryDSL을 사용하면 좋을 것 같음

Closes #63
