### PR TITLE
[feat] 사용자 정보 조회 및 수정 API 구현

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/UsersController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/UsersController.java
@@ -3,8 +3,10 @@ package com.service.sport_companion.api.controller;
 import com.service.sport_companion.api.service.UsersService;
 import com.service.sport_companion.domain.model.annotation.CallUser;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.user.UserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class UsersController {
 
   private final UsersService usersService;
+
+  @GetMapping
+  public ResponseEntity<ResultResponse<UserInfo>> getUserInfo(@CallUser Long userId) {
+
+    ResultResponse<UserInfo> response = usersService.getUserInfo(userId);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
 
   @PutMapping("/{nickname}")
   public ResponseEntity<ResultResponse<Void>> updateUserInfo(

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/UsersController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/UsersController.java
@@ -1,0 +1,29 @@
+package com.service.sport_companion.api.controller;
+
+import com.service.sport_companion.api.service.UsersService;
+import com.service.sport_companion.domain.model.annotation.CallUser;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UsersController {
+
+  private final UsersService usersService;
+
+  @PutMapping("/{nickname}")
+  public ResponseEntity<ResultResponse<Void>> updateUserInfo(
+      @CallUser Long userId,
+      @PathVariable("nickname") String nickname) {
+
+    ResultResponse<Void> response = usersService.updateUserInfo(userId, nickname);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/UsersService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/UsersService.java
@@ -1,0 +1,8 @@
+package com.service.sport_companion.api.service;
+
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+
+public interface UsersService {
+
+  ResultResponse<Void> updateUserInfo(Long userId, String nickname);
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/UsersService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/UsersService.java
@@ -1,8 +1,11 @@
 package com.service.sport_companion.api.service;
 
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.user.UserInfo;
 
 public interface UsersService {
 
   ResultResponse<Void> updateUserInfo(Long userId, String nickname);
+
+  ResultResponse<UserInfo> getUserInfo(Long userId);
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/UsersServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/UsersServiceImpl.java
@@ -4,6 +4,7 @@ import com.service.sport_companion.api.component.UserHandler;
 import com.service.sport_companion.api.service.UsersService;
 import com.service.sport_companion.domain.entity.UsersEntity;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.user.UserInfo;
 import com.service.sport_companion.domain.model.type.SuccessResultType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,5 +31,13 @@ public class UsersServiceImpl implements UsersService {
     );
 
     return ResultResponse.of(SuccessResultType.SUCCESS_UPDATE_USERINFO);
+  }
+
+  @Override
+  public ResultResponse<UserInfo> getUserInfo(Long userId) {
+    UsersEntity user = userHandler.findByUserId(userId);
+
+    UserInfo userInfo = new UserInfo(user.getEmail(), user.getNickname());
+    return new ResultResponse<>(SuccessResultType.SUCCESS_GET_USERINFO, userInfo);
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/UsersServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/UsersServiceImpl.java
@@ -1,0 +1,34 @@
+package com.service.sport_companion.api.service.impl;
+
+import com.service.sport_companion.api.component.UserHandler;
+import com.service.sport_companion.api.service.UsersService;
+import com.service.sport_companion.domain.entity.UsersEntity;
+import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.type.SuccessResultType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UsersServiceImpl implements UsersService {
+
+  private final UserHandler userHandler;
+
+  @Override
+  public ResultResponse<Void> updateUserInfo(Long userId, String nickname) {
+    UsersEntity user = userHandler.findByUserId(userId);
+
+    userHandler.saveUser(UsersEntity.builder()
+        .userId(user.getUserId())
+        .email(user.getEmail())
+        .nickname(nickname)
+        .provider(user.getProvider())
+        .providerId(user.getProviderId())
+        .role(user.getRole())
+        .createdAt(user.getCreatedAt())
+        .build()
+    );
+
+    return ResultResponse.of(SuccessResultType.SUCCESS_UPDATE_USERINFO);
+  }
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/user/UserInfo.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/user/UserInfo.java
@@ -1,0 +1,13 @@
+package com.service.sport_companion.domain.model.dto.response.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserInfo {
+
+  private String email;
+  private String nickname;
+
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -15,6 +15,7 @@ public enum SuccessResultType {
   AVAILABLE_NICKNAME(HttpStatus.OK, "사용 가능한 닉네임입니다."),
   UNAVAILABLE_NICKNAME(HttpStatus.OK, "이미 사용 중인 닉네임입니다."),
   SUCCESS_REISSUE_TOKEN(HttpStatus.OK, "Access 토큰 재발급 성공."),
+  SUCCESS_GET_USERINFO(HttpStatus.OK, "회원 정보 조회 성공"),
   SUCCESS_UPDATE_USERINFO(HttpStatus.OK, "회원 정보 수정 성공"),
 
   //Club

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -15,6 +15,7 @@ public enum SuccessResultType {
   AVAILABLE_NICKNAME(HttpStatus.OK, "사용 가능한 닉네임입니다."),
   UNAVAILABLE_NICKNAME(HttpStatus.OK, "이미 사용 중인 닉네임입니다."),
   SUCCESS_REISSUE_TOKEN(HttpStatus.OK, "Access 토큰 재발급 성공."),
+  SUCCESS_UPDATE_USERINFO(HttpStatus.OK, "회원 정보 수정 성공"),
 
   //Club
   SUCCESS_GET_ALL_CLUBS_LIST(HttpStatus.OK, "모든 구단 조회 성공!"),


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 마이페이지  
   - 회원정보 조회
       - 이메일, 닉네임 반환  
   - 회원정보 수정 
       - 닉네임 중복 로직은 따로 존재하기 때문에, 중복 검증 후 서버측으로 닉네임 전달
       - 토큰 값에서 userId를 추출 후 해당 사용자 정보 업데이트

## 스크린샷

## 주의사항

Closes #70 
