### PR TITLE
[feat] 이번주 투표 주제 및 투표 결과 조회

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtFilter.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtFilter.java
@@ -131,6 +131,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
   public boolean isMatchingGetRequest(AntPathMatcher pathMatcher, String requestURI) {
 
-    return pathMatcher.match("/api/v1/fixture", requestURI);
+    return pathMatcher.match("/api/v1/fixture", requestURI)
+        || pathMatcher.match("/api/v1/topic/top5", requestURI);
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CandidateHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/CandidateHandler.java
@@ -1,6 +1,7 @@
 package com.service.sport_companion.api.component;
 
 import com.service.sport_companion.domain.entity.CandidateEntity;
+import com.service.sport_companion.domain.model.dto.response.vote.CandidateAndCountDto;
 import com.service.sport_companion.domain.repository.CandidateRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +17,12 @@ public class CandidateHandler {
     candidateRepository.save(candidateEntity);
   }
 
-  public List<CandidateEntity> getCandidateByVoteId(Long voteId) {
+  public List<CandidateEntity> findByVoteIdOrderBySequence(Long voteId) {
     return candidateRepository.findByVoteEntity_VoteIdOrderBySequence(voteId);
+  }
+
+  public List<CandidateAndCountDto> getCandidateByVoteId(Long voteId) {
+    return candidateRepository.findEntityAndCountByVoteId(voteId);
   }
 
   public void deleteVoteByVoteId(Long voteId) {

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/VoteHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/VoteHandler.java
@@ -34,4 +34,9 @@ public class VoteHandler {
   public boolean existByStartDate(LocalDate startDate) {
     return voteRepository.existsByStartDate(startDate);
   }
+
+  public VoteEntity findByDate(LocalDate voteStartDate) {
+    return voteRepository.findByStartDateBetween(voteStartDate, voteStartDate)
+      .orElseThrow(() -> new GlobalException(FailedResultType.CANT_GET_VOTE_RESULT));
+  }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                 "/api/v1/fixture/crawl",
                 "/favicon.ico").permitAll()
             .requestMatchers(HttpMethod.GET,
+                "/api/v1/topic/top5",
                 "api/v1/vote/**").authenticated()
             .requestMatchers(
                 "api/v1/vote/**").hasRole(UserRole.ADMIN.name())

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/VoteController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/VoteController.java
@@ -3,10 +3,13 @@ package com.service.sport_companion.api.controller;
 import com.service.sport_companion.api.service.VoteService;
 import com.service.sport_companion.domain.model.annotation.CallUser;
 import com.service.sport_companion.domain.model.dto.request.vote.CreateVoteDto;
+import com.service.sport_companion.domain.model.dto.request.vote.GetVoteResult;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.vote.VoteResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -44,6 +47,22 @@ public class VoteController {
     @PathVariable("voteId") Long voteId
   ) {
     ResultResponse<Void> response = voteService.deleteVote(userId, voteId);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @GetMapping
+  public ResponseEntity<ResultResponse<VoteResponse>> getThisWeekVote() {
+    ResultResponse<VoteResponse> response = voteService.getThisWeekVote();
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @GetMapping("/result")
+  public ResponseEntity<ResultResponse<VoteResponse>> getVoteResult(@CallUser Long userId,
+    GetVoteResult getVoteResult
+  ) {
+    ResultResponse<VoteResponse> response = voteService.getVoteResult(userId, getVoteResult);
 
     return new ResponseEntity<>(response, response.getStatus());
   }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/VoteService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/VoteService.java
@@ -1,7 +1,9 @@
 package com.service.sport_companion.api.service;
 
 import com.service.sport_companion.domain.model.dto.request.vote.CreateVoteDto;
+import com.service.sport_companion.domain.model.dto.request.vote.GetVoteResult;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.vote.VoteResponse;
 
 public interface VoteService {
 
@@ -10,4 +12,8 @@ public interface VoteService {
   ResultResponse<Void> updateVote(Long userId, Long voteId, CreateVoteDto voteDto);
 
   ResultResponse<Void> deleteVote(Long userId, Long voteId);
+
+  ResultResponse<VoteResponse> getThisWeekVote();
+
+  ResultResponse<VoteResponse> getVoteResult(Long userId, GetVoteResult getVoteResult);
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/CustomTopicServiceImpl.java
@@ -113,6 +113,6 @@ public class CustomTopicServiceImpl implements CustomTopicService {
   }
 
   private boolean isAuthor(Long userId, Long authorId) {
-    return userId.equals(authorId);
+    return authorId.equals(userId);
   }
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/request/vote/GetVoteResult.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/request/vote/GetVoteResult.java
@@ -1,0 +1,24 @@
+package com.service.sport_companion.domain.model.dto.request.vote;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class GetVoteResult {
+
+  private LocalDate startDate;
+
+  @JsonCreator
+  public GetVoteResult(
+    @JsonProperty("startDate") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate
+  ) {
+    this.startDate = startDate;
+  }
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/vote/CandidateAndCountDto.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/vote/CandidateAndCountDto.java
@@ -1,0 +1,13 @@
+package com.service.sport_companion.domain.model.dto.response.vote;
+
+import com.service.sport_companion.domain.entity.CandidateEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CandidateAndCountDto {
+
+  private CandidateEntity candidateEntity;
+  private Long voteCount;
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/vote/VoteResponse.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/vote/VoteResponse.java
@@ -1,0 +1,75 @@
+package com.service.sport_companion.domain.model.dto.response.vote;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.service.sport_companion.domain.entity.CandidateEntity;
+import com.service.sport_companion.domain.entity.VoteEntity;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class VoteResponse {
+
+  private Long voteId;
+
+  @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/seoul")
+  private LocalDate startDate;
+
+  private String topic;
+
+  private List<Vote> vote;
+
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  static class Vote {
+
+    private String example;
+    private Long voteCount;
+  }
+
+  // 투표 결과는 리턴하지 않는 생성자
+  public static VoteResponse fromExample(VoteEntity voteEntity,
+    List<CandidateEntity> candidateList
+  ) {
+    List<Vote> voteList = candidateList.stream().map(
+      candidate -> Vote.builder()
+        .example(candidate.getExample())
+        .build()
+    ).toList();
+
+    return VoteResponse.builder()
+      .voteId(voteEntity.getVoteId())
+      .startDate(voteEntity.getStartDate())
+      .topic(voteEntity.getTopic())
+      .vote(voteList)
+      .build();
+  }
+
+  // 투표 결과를 함께 리턴하는 생성자
+  public static VoteResponse fromExampleAndVoteCount(VoteEntity voteEntity,
+    List<CandidateAndCountDto> candidateList
+  ) {
+    List<Vote> voteList = candidateList.stream().map(
+      candidate -> Vote.builder()
+        .example(candidate.getCandidateEntity().getExample())
+        .voteCount(candidate.getVoteCount())
+        .build()
+    ).toList();
+
+    return VoteResponse.builder()
+      .voteId(voteEntity.getVoteId())
+      .startDate(voteEntity.getStartDate())
+      .topic(voteEntity.getTopic())
+      .vote(voteList)
+      .build();
+  }
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
@@ -42,6 +42,7 @@ public enum FailedResultType {
   // Vote
   VOTE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 투표입니다."),
   ALREADY_EXISTS_VOTE_DATE(HttpStatus.BAD_REQUEST, "이미 해당 날짜에 투표가 존재합니다."),
+  CANT_GET_VOTE_RESULT(HttpStatus.BAD_REQUEST, "투표 결과를 조회할 수 없습니다"),
 
   ;
 

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -37,6 +37,7 @@ public enum SuccessResultType {
   SUCCESS_CREATE_VOTE(HttpStatus.CREATED, "투표가 등록되었습니다."),
   SUCCESS_MODIFY_VOTE(HttpStatus.OK, "투표가 수정되었습니다."),
   SUCCESS_DELETE_VOTE(HttpStatus.OK, "투표가 삭제되었습니다."),
+  SUCCESS_GET_VOTE(HttpStatus.OK, "투표를 성공적으로 조회했습니다."),
 
   ;
 

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CandidateRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/CandidateRepository.java
@@ -1,14 +1,25 @@
 package com.service.sport_companion.domain.repository;
 
 import com.service.sport_companion.domain.entity.CandidateEntity;
+import com.service.sport_companion.domain.model.dto.response.vote.CandidateAndCountDto;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CandidateRepository extends JpaRepository<CandidateEntity, Long> {
 
   List<CandidateEntity> findByVoteEntity_VoteIdOrderBySequence(Long voteId);
+
+  @Query("SELECT new com.service.sport_companion.domain.model.dto.response.vote.CandidateAndCountDto(c, COUNT(u)) "
+    + "FROM CandidateEntity c "
+    + "LEFT JOIN UserVoteEntity u ON c = u.candidateEntity "
+    + "WHERE c.voteEntity.voteId = :voteId "
+    + "GROUP BY c "
+    + "ORDER BY c.sequence")
+  List<CandidateAndCountDto> findEntityAndCountByVoteId(@Param("voteId") Long voteId);
 
   void deleteByVoteEntity_VoteId(Long voteId);
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/VoteRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/VoteRepository.java
@@ -2,6 +2,7 @@ package com.service.sport_companion.domain.repository;
 
 import com.service.sport_companion.domain.entity.VoteEntity;
 import java.time.LocalDate;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface VoteRepository extends JpaRepository<VoteEntity, Long> {
 
   boolean existsByStartDate(LocalDate startDate);
+
+  Optional<VoteEntity> findByStartDateBetween(LocalDate voteStartDate, LocalDate voteEndDate);
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
**요청/응답 DTO 정의**
- VoteResponse
  - 조회 요청 API에서 응답할 값으로 voteId, 투표일, 주제, 그리고 내부 클래스 Vote를 통해 투표 내용, 득표수를 반환
  - 득표수를 반환하지 않는 생성자와 반환하는 생성자로 나눠서 생성
- GetVoteResult
  - 투표 결과 조회 요청 파라미터 DTO로, 조회하고자 하는 날짜를 저장
- CandidateAndCountDto
  - repository에서 투표 내용과 득표수를 함께 조회하기 위해 사용하는 DTO

**이번주 투표 주제 조회 API 구현**
- DB에 투표의 시작 날짜가 저장되어 있으므로 이번주 월요일 날짜로 저장된 투표를 가져온다.
- 투표와 투표 결과를 각각의 테이블에서 조회하여 반환

**날짜별 투표 결과 조회 API 구현**
- 날짜를 지정하여 결과를 조회하며, 기본값은 이번주 투표 결과 반환
- 투표와 투표 결과를 각각의 테이블에서 조회하고, 사용자 투표(UserVote) 테이블을 Join하여 득표율과 함께 반환
- 조회 방식에 따라 수정될 수 있음

## 스크린샷

## 주의사항
- Entity에서 투표와 투표 결과를 양방향 매핑으로 가져오는 방식 고려

Closes #69
