### PR TITLE
[feat] 사용자 투표하기 기능 구현

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/UserVoteHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/UserVoteHandler.java
@@ -1,0 +1,21 @@
+package com.service.sport_companion.api.component;
+
+import com.service.sport_companion.domain.repository.UserVoteRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserVoteHandler {
+
+  private final UserVoteRepository userVoteRepository;
+
+  public boolean isVotedToday(Long userId) {
+    return userVoteRepository.findTodayVote(userId, LocalDate.now()).isPresent();
+  }
+
+  public void vote(Long userId, Long candidateId) {
+    userVoteRepository.vote(userId, candidateId);
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/VoteHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/VoteHandler.java
@@ -39,4 +39,9 @@ public class VoteHandler {
     return voteRepository.findByStartDateBetween(voteStartDate, voteStartDate)
       .orElseThrow(() -> new GlobalException(FailedResultType.CANT_GET_VOTE_RESULT));
   }
+
+  public VoteEntity findById(Long voteId) {
+    return voteRepository.findById(voteId)
+      .orElseThrow(() -> new GlobalException(FailedResultType.CANT_GET_VOTE_RESULT));
+  }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/VoteController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/VoteController.java
@@ -5,6 +5,7 @@ import com.service.sport_companion.domain.model.annotation.CallUser;
 import com.service.sport_companion.domain.model.dto.request.vote.CreateVoteDto;
 import com.service.sport_companion.domain.model.dto.request.vote.GetVoteResult;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.vote.CheckVotedResponse;
 import com.service.sport_companion.domain.model.dto.response.vote.VoteResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -63,6 +64,22 @@ public class VoteController {
     GetVoteResult getVoteResult
   ) {
     ResultResponse<VoteResponse> response = voteService.getVoteResult(userId, getVoteResult);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @GetMapping("/user")
+  public ResponseEntity<ResultResponse<CheckVotedResponse>> checkUserVoted(@CallUser Long userId) {
+    ResultResponse<CheckVotedResponse> response = voteService.checkUserVoted(userId);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @PostMapping("{voteId}/candidate/{candidateId}")
+  public ResponseEntity<ResultResponse<VoteResponse>> vote(@CallUser Long userId,
+    @PathVariable("voteId") Long voteId, @PathVariable("candidateId") Long candidateId
+  ) {
+    ResultResponse<VoteResponse> response = voteService.vote(userId, voteId, candidateId);
 
     return new ResponseEntity<>(response, response.getStatus());
   }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/VoteService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/VoteService.java
@@ -3,6 +3,7 @@ package com.service.sport_companion.api.service;
 import com.service.sport_companion.domain.model.dto.request.vote.CreateVoteDto;
 import com.service.sport_companion.domain.model.dto.request.vote.GetVoteResult;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.vote.CheckVotedResponse;
 import com.service.sport_companion.domain.model.dto.response.vote.VoteResponse;
 
 public interface VoteService {
@@ -16,4 +17,8 @@ public interface VoteService {
   ResultResponse<VoteResponse> getThisWeekVote();
 
   ResultResponse<VoteResponse> getVoteResult(Long userId, GetVoteResult getVoteResult);
+
+  ResultResponse<CheckVotedResponse> checkUserVoted(Long userId);
+
+  ResultResponse<VoteResponse> vote(Long userId, Long voteId, Long candidateId);
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/VoteEntity.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/VoteEntity.java
@@ -1,12 +1,15 @@
 package com.service.sport_companion.domain.entity;
 
 import com.service.sport_companion.domain.model.dto.request.vote.CreateVoteDto;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,6 +30,9 @@ public class VoteEntity {
   private LocalDate startDate;
 
   private String topic;
+
+  @OneToMany(mappedBy = "voteEntity", orphanRemoval = true, cascade = CascadeType.REMOVE)
+  private List<CandidateEntity> candidateEntity;
 
   public void update(CreateVoteDto voteDto) {
     this.startDate = voteDto.getStartDate();

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/vote/CheckVotedResponse.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/vote/CheckVotedResponse.java
@@ -1,0 +1,11 @@
+package com.service.sport_companion.domain.model.dto.response.vote;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CheckVotedResponse {
+
+  private Boolean voted;
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/FailedResultType.java
@@ -43,6 +43,9 @@ public enum FailedResultType {
   VOTE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 투표입니다."),
   ALREADY_EXISTS_VOTE_DATE(HttpStatus.BAD_REQUEST, "이미 해당 날짜에 투표가 존재합니다."),
   CANT_GET_VOTE_RESULT(HttpStatus.BAD_REQUEST, "투표 결과를 조회할 수 없습니다"),
+  CANDIDATE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 후보입니다."),
+  CANT_VOTE_PERIOD(HttpStatus.BAD_REQUEST, "투표 가능 기간이 아닙니다."),
+  ALREADY_VOTE_TODAY(HttpStatus.BAD_REQUEST, "오늘 이미 투표를 했습니다."),
 
   // Club
   SUPPORT_CLUB_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "선호 구단은 1개만 등록 할 수 있습니다"),

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -43,6 +43,8 @@ public enum SuccessResultType {
   SUCCESS_MODIFY_VOTE(HttpStatus.OK, "투표가 수정되었습니다."),
   SUCCESS_DELETE_VOTE(HttpStatus.OK, "투표가 삭제되었습니다."),
   SUCCESS_GET_VOTE(HttpStatus.OK, "투표를 성공적으로 조회했습니다."),
+  SUCCESS_CHECK_VOTED(HttpStatus.OK, "투표 여부를 확인했습니다."),
+  SUCCESS_VOTING(HttpStatus.OK, "투표를 완료했습니다."),
 
   ;
 

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/UserVoteRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/UserVoteRepository.java
@@ -1,10 +1,28 @@
 package com.service.sport_companion.domain.repository;
 
 import com.service.sport_companion.domain.entity.UserVoteEntity;
+import java.time.LocalDate;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserVoteRepository extends JpaRepository<UserVoteEntity, Long> {
 
+  @Query("SELECT u FROM UserVoteEntity u "
+    + "WHERE u.usersEntity.userId = :userId AND "
+    + "FUNCTION('DATE', u.voteDateTime) = :date")
+  Optional<UserVoteEntity> findTodayVote(
+    @Param("userId") Long userId,
+    @Param("date") LocalDate date
+  );
+
+  @Modifying
+  @Query(value = "INSERT "
+    + "INTO user_vote(user_id, candidate_id, vote_date_time) "
+    + "VALUES(:userId, :candidateId, now())", nativeQuery = true)
+  void vote(@Param("userId") Long userId, @Param("candidateId") Long candidateId);
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 작업 내용
**VoteEntity에 List\<CandidateEntity\> 추가**
- Vote(투표)를 조회할 때는 무조건 Candidate(후보)를 함께 조회하므로 양방향 매핑으로 연결하여 조회 시, 같이 가져올 수 있도록 한다.

**투표 여부 확인 API 구현**
- 사용자가 투표했는지 확인하는 API
- DB에서 오늘 날짜에 사용자 투표 기록이 있는지 확인한다.

**투표 API 구현**
- **예외 처리** : 오늘 투표한 적 있는 경우 / 현재 투표할 수 없는 투표 / 투표에 일치하는 후보가 없는 경우
- **투표** : UserVote 테이블에 사용자id와 사용자가 고른 후보id를 저장하는 방식으로 투표
- 투표 후의 결과도 함께 리턴

## 스크린샷

## 주의사항

Closes #75
