### PR TITLE
[fix] 투표 결과 조회 API 수정

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/VoteHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/VoteHandler.java
@@ -7,6 +7,8 @@ import com.service.sport_companion.domain.model.type.FailedResultType;
 import com.service.sport_companion.domain.repository.VoteRepository;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -43,5 +45,15 @@ public class VoteHandler {
   public VoteEntity findById(Long voteId) {
     return voteRepository.findById(voteId)
       .orElseThrow(() -> new GlobalException(FailedResultType.CANT_GET_VOTE_RESULT));
+  }
+
+  // 지난 투표 최신순 조회
+  public Page<VoteEntity> findPrevVoteOrderByUpToDate(LocalDate thisWeekDate, Pageable pageable) {
+    return voteRepository.findByStartDateBeforeOrderByStartDateDesc(thisWeekDate, pageable);
+  }
+
+  // 지난 투표 인기순(투표 참여율이 높은순) 조회
+  public Page<VoteEntity> findPrevVoteOrderByParticipant(LocalDate thisWeekDate, Pageable pageable) {
+    return voteRepository.findAllOrderByParticipant(thisWeekDate, pageable);
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/VoteController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/VoteController.java
@@ -3,11 +3,13 @@ package com.service.sport_companion.api.controller;
 import com.service.sport_companion.api.service.VoteService;
 import com.service.sport_companion.domain.model.annotation.CallUser;
 import com.service.sport_companion.domain.model.dto.request.vote.CreateVoteDto;
-import com.service.sport_companion.domain.model.dto.request.vote.GetVoteResult;
+import com.service.sport_companion.domain.model.dto.response.PageResponse;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import com.service.sport_companion.domain.model.dto.response.vote.CheckVotedResponse;
 import com.service.sport_companion.domain.model.dto.response.vote.VoteResponse;
+import com.service.sport_companion.domain.model.type.SortType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -60,10 +63,19 @@ public class VoteController {
   }
 
   @GetMapping("/result")
-  public ResponseEntity<ResultResponse<VoteResponse>> getVoteResult(@CallUser Long userId,
-    GetVoteResult getVoteResult
+  public ResponseEntity<ResultResponse<VoteResponse>> getThisWeekVoteResult(@CallUser Long userId) {
+    ResultResponse<VoteResponse> response = voteService.getThisWeekVoteResult(userId);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @GetMapping("/result/prev")
+  public ResponseEntity<ResultResponse<PageResponse<VoteResponse>>> getPrevVoteResult(
+    @CallUser Long userId,
+    @RequestParam(defaultValue = "UP_TO_DATE") SortType sortType,
+    Pageable pageable
   ) {
-    ResultResponse<VoteResponse> response = voteService.getVoteResult(userId, getVoteResult);
+    ResultResponse<PageResponse<VoteResponse>> response = voteService.getPrevVoteResult(userId, sortType, pageable);
 
     return new ResponseEntity<>(response, response.getStatus());
   }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/VoteService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/VoteService.java
@@ -1,10 +1,12 @@
 package com.service.sport_companion.api.service;
 
 import com.service.sport_companion.domain.model.dto.request.vote.CreateVoteDto;
-import com.service.sport_companion.domain.model.dto.request.vote.GetVoteResult;
+import com.service.sport_companion.domain.model.dto.response.PageResponse;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import com.service.sport_companion.domain.model.dto.response.vote.CheckVotedResponse;
 import com.service.sport_companion.domain.model.dto.response.vote.VoteResponse;
+import com.service.sport_companion.domain.model.type.SortType;
+import org.springframework.data.domain.Pageable;
 
 public interface VoteService {
 
@@ -16,7 +18,9 @@ public interface VoteService {
 
   ResultResponse<VoteResponse> getThisWeekVote();
 
-  ResultResponse<VoteResponse> getVoteResult(Long userId, GetVoteResult getVoteResult);
+  ResultResponse<VoteResponse> getThisWeekVoteResult(Long userId);
+
+  ResultResponse<PageResponse<VoteResponse>> getPrevVoteResult(Long userId, SortType sortType, Pageable pageable);
 
   ResultResponse<CheckVotedResponse> checkUserVoted(Long userId);
 

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/VoteServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/VoteServiceImpl.java
@@ -205,7 +205,7 @@ public class VoteServiceImpl implements VoteService {
     return userVoteHandler.findUserVotedCandidate(
       userId,
       candidateList.stream()
-        .mapToLong(x -> x.getCandidateEntity().getCandidateId())
+        .mapToLong(candidate -> candidate.getCandidateEntity().getCandidateId())
         .boxed()
         .toList()
     );

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/VoteServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/VoteServiceImpl.java
@@ -196,6 +196,7 @@ public class VoteServiceImpl implements VoteService {
       .with(TemporalAdjusters.previousOrSame(dayOfWeek));
   }
 
+  // 사용자가 후보 List 중에서 투표한 곳을 조회
   private Long getUserVotedCandidateId(Long userId, List<CandidateAndCountDto> candidateList) {
     if (userId == null) {
       return null;
@@ -210,6 +211,7 @@ public class VoteServiceImpl implements VoteService {
     );
   }
 
+  // 지난 투표를 원하는 정렬 조건에 맞는 순서로 pageable 크기만큼 조회
   private Page<VoteEntity> getPrevVoteListBySortType(SortType sortType, Pageable pageable) {
     if (sortType.equals(SortType.PARTICIPANT)) {
       return voteHandler.findPrevVoteOrderByParticipant(getVoteStartDate(DayOfWeek.MONDAY), pageable);

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/VoteServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/VoteServiceImpl.java
@@ -8,12 +8,13 @@ import com.service.sport_companion.core.exception.GlobalException;
 import com.service.sport_companion.domain.entity.CandidateEntity;
 import com.service.sport_companion.domain.entity.VoteEntity;
 import com.service.sport_companion.domain.model.dto.request.vote.CreateVoteDto;
-import com.service.sport_companion.domain.model.dto.request.vote.GetVoteResult;
+import com.service.sport_companion.domain.model.dto.response.PageResponse;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import com.service.sport_companion.domain.model.dto.response.vote.CandidateAndCountDto;
 import com.service.sport_companion.domain.model.dto.response.vote.CheckVotedResponse;
 import com.service.sport_companion.domain.model.dto.response.vote.VoteResponse;
 import com.service.sport_companion.domain.model.type.FailedResultType;
+import com.service.sport_companion.domain.model.type.SortType;
 import com.service.sport_companion.domain.model.type.SuccessResultType;
 import jakarta.transaction.Transactional;
 import java.time.DayOfWeek;
@@ -21,6 +22,8 @@ import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -110,28 +113,45 @@ public class VoteServiceImpl implements VoteService {
   }
 
   @Override
-  public ResultResponse<VoteResponse> getVoteResult(Long userId, GetVoteResult getVoteResultDto) {
-    // 입력된 날짜가 없을 경우 이번주 결과를 조회
-    if (getVoteResultDto.getStartDate() == null) {
-      getVoteResultDto.setStartDate(getVoteStartDate(DayOfWeek.MONDAY));
-    }
-
-    VoteEntity voteEntity = voteHandler.findByDate(getVoteResultDto.getStartDate());
-    List<CandidateAndCountDto> candidateEntity =
+  public ResultResponse<VoteResponse> getThisWeekVoteResult(Long userId) {
+    // 이번주 투표와 결과 조회
+    VoteEntity voteEntity = voteHandler.findByDate(getVoteStartDate(DayOfWeek.MONDAY));
+    List<CandidateAndCountDto> candidateList =
       candidateHandler.getCandidateByVoteId(voteEntity.getVoteId());
 
-    Long votedCandidateId = userVoteHandler.findUserVotedCandidate(
-      userId,
-      candidateEntity.stream()
-        .mapToLong(x -> x.getCandidateEntity().getCandidateId())
-        .boxed()
-        .toList()
-    );
+    Long userVotedCandidateId = getUserVotedCandidateId(userId, candidateList);
 
     return new ResultResponse<>(
       SuccessResultType.SUCCESS_GET_VOTE,
-      VoteResponse.fromExampleAndVoteCount(voteEntity, candidateEntity, votedCandidateId)
+      VoteResponse.fromExampleAndVoteCount(voteEntity, candidateList, userVotedCandidateId)
     );
+  }
+
+  @Override
+  public ResultResponse<PageResponse<VoteResponse>> getPrevVoteResult(
+    Long userId, SortType sortType, Pageable pageable
+  ) {
+    Page<VoteEntity> voteEntityList = getPrevVoteListBySortType(sortType, pageable);
+
+    // 조회한 투표 별로 투표의 결과와 내가 투표한 후보 id 조회
+    List<VoteResponse> response = voteEntityList.stream()
+      .map(voteEntity -> {
+        List<CandidateAndCountDto> candidateList =
+          candidateHandler.getCandidateByVoteId(voteEntity.getVoteId());
+
+        Long votedCandidateId = getUserVotedCandidateId(userId, candidateList);
+
+        return VoteResponse.fromExampleAndVoteCount(voteEntity, candidateList, votedCandidateId);
+      })
+      .toList();
+
+    return new ResultResponse<>(SuccessResultType.SUCCESS_GET_VOTE,
+      new PageResponse<>(
+        voteEntityList.getNumber(),
+        voteEntityList.getTotalPages(),
+        voteEntityList.getTotalElements(),
+        response
+      ));
   }
 
   @Override
@@ -174,5 +194,27 @@ public class VoteServiceImpl implements VoteService {
   private LocalDate getVoteStartDate(DayOfWeek dayOfWeek) {
     return LocalDate.now()
       .with(TemporalAdjusters.previousOrSame(dayOfWeek));
+  }
+
+  private Long getUserVotedCandidateId(Long userId, List<CandidateAndCountDto> candidateList) {
+    if (userId == null) {
+      return null;
+    }
+
+    return userVoteHandler.findUserVotedCandidate(
+      userId,
+      candidateList.stream()
+        .mapToLong(x -> x.getCandidateEntity().getCandidateId())
+        .boxed()
+        .toList()
+    );
+  }
+
+  private Page<VoteEntity> getPrevVoteListBySortType(SortType sortType, Pageable pageable) {
+    if (sortType.equals(SortType.PARTICIPANT)) {
+      return voteHandler.findPrevVoteOrderByParticipant(getVoteStartDate(DayOfWeek.MONDAY), pageable);
+    } else {
+      return voteHandler.findPrevVoteOrderByUpToDate(getVoteStartDate(DayOfWeek.MONDAY), pageable);
+    }
   }
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SortType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SortType.java
@@ -1,0 +1,10 @@
+package com.service.sport_companion.domain.model.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SortType {
+  UP_TO_DATE, PARTICIPANT
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/VoteRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/VoteRepository.java
@@ -3,7 +3,10 @@ package com.service.sport_companion.domain.repository;
 import com.service.sport_companion.domain.entity.VoteEntity;
 import java.time.LocalDate;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,4 +15,14 @@ public interface VoteRepository extends JpaRepository<VoteEntity, Long> {
   boolean existsByStartDate(LocalDate startDate);
 
   Optional<VoteEntity> findByStartDateBetween(LocalDate voteStartDate, LocalDate voteEndDate);
+
+  Page<VoteEntity> findByStartDateBeforeOrderByStartDateDesc(LocalDate startDate, Pageable pageable);
+
+  @Query("SELECT v "
+    + "FROM VoteEntity v JOIN CandidateEntity c ON v = c.voteEntity "
+    + "LEFT JOIN UserVoteEntity u ON u.candidateEntity = c "
+    + "WHERE v.startDate < :startDate "
+    + "GROUP BY v.voteId "
+    + "ORDER BY count(*) DESC")
+  Page<VoteEntity> findAllOrderByParticipant(LocalDate startDate, Pageable pageable);
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
: 기존 날짜별 투표 결과 조회 **->** 이번주 투표 / 지난 투표 결과 조회 API로 분리

**요청할 정렬 조건을 정의한 SortType Enum 추가**
- UP_TO_DATE : 최신순
- PARTICIPANT : 인기순 (투표 참여율이 높은순)

**이번주 투표 결과 조회**
- 투표하지 않은 사용자 요청 시, 예외 처리

**지난 투표 결과 조회**
- 입력 받은 원하는 정렬 조건과 page 크기만큼 지난 투표 조회

## 스크린샷
![image (2)](https://github.com/user-attachments/assets/a0300613-c8ca-4455-9c60-756c119b1219)
<p align="center">▼</p>

![image (3)](https://github.com/user-attachments/assets/2faafbac-deec-4d47-923c-bd3a0ed521aa)

## 주의사항

Closes #81
