### PR TITLE
[refactor] Vote-Candidate 양방향 매핑을 통해 필요없는 조회 삭제

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/VoteServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/VoteServiceImpl.java
@@ -103,12 +103,10 @@ public class VoteServiceImpl implements VoteService {
     LocalDate voteStartDate = getVoteStartDate(DayOfWeek.MONDAY);
 
     VoteEntity voteEntity = voteHandler.findByDate(voteStartDate);
-    List<CandidateEntity> candidateEntity =
-      candidateHandler.findByVoteIdOrderBySequence(voteEntity.getVoteId());
 
     return new ResultResponse<>(
       SuccessResultType.SUCCESS_GET_VOTE,
-      VoteResponse.fromExample(voteEntity, candidateEntity)
+      VoteResponse.fromExample(voteEntity)
     );
   }
 

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/VoteServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/VoteServiceImpl.java
@@ -106,7 +106,7 @@ public class VoteServiceImpl implements VoteService {
 
     return new ResultResponse<>(
       SuccessResultType.SUCCESS_GET_VOTE,
-      VoteResponse.fromExample(voteEntity)
+      VoteResponse.fromEntity(voteEntity)
     );
   }
 
@@ -121,7 +121,7 @@ public class VoteServiceImpl implements VoteService {
 
     return new ResultResponse<>(
       SuccessResultType.SUCCESS_GET_VOTE,
-      VoteResponse.fromExampleAndVoteCount(voteEntity, candidateList, userVotedCandidateId)
+      VoteResponse.fromEntityWithResult(voteEntity, candidateList, userVotedCandidateId)
     );
   }
 
@@ -139,7 +139,7 @@ public class VoteServiceImpl implements VoteService {
 
         Long votedCandidateId = getUserVotedCandidateId(userId, candidateList);
 
-        return VoteResponse.fromExampleAndVoteCount(voteEntity, candidateList, votedCandidateId);
+        return VoteResponse.fromEntityWithResult(voteEntity, candidateList, votedCandidateId);
       })
       .toList();
 
@@ -183,7 +183,7 @@ public class VoteServiceImpl implements VoteService {
 
     return new ResultResponse<>(
       SuccessResultType.SUCCESS_VOTING,
-      VoteResponse.fromExampleAndVoteCount(
+      VoteResponse.fromEntityWithResult(
         voteEntity, candidateHandler.getCandidateByVoteId(voteId), candidateId)
     );
   }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/vote/VoteResponse.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/vote/VoteResponse.java
@@ -39,7 +39,7 @@ public class VoteResponse {
   }
 
   // 투표 결과는 리턴하지 않는 생성자
-  public static VoteResponse fromExample(VoteEntity voteEntity) {
+  public static VoteResponse fromEntity(VoteEntity voteEntity) {
     List<Vote> voteList = voteEntity.getCandidateEntity().stream().map(
       candidate -> Vote.builder()
         .candidateId(candidate.getCandidateId())
@@ -56,8 +56,9 @@ public class VoteResponse {
   }
 
   // 투표 결과를 함께 리턴하는 생성자
-  public static VoteResponse fromExampleAndVoteCount(VoteEntity voteEntity,
-    List<CandidateAndCountDto> candidateList, Long myVote
+  public static VoteResponse fromEntityWithResult(VoteEntity voteEntity,
+    List<CandidateAndCountDto> candidateList,
+    Long myVote
   ) {
     List<Vote> voteList = candidateList.stream().map(
       candidate -> Vote.builder()

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/vote/VoteResponse.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/vote/VoteResponse.java
@@ -1,7 +1,6 @@
 package com.service.sport_companion.domain.model.dto.response.vote;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.service.sport_companion.domain.entity.CandidateEntity;
 import com.service.sport_companion.domain.entity.VoteEntity;
 import java.time.LocalDate;
 import java.util.List;
@@ -40,10 +39,8 @@ public class VoteResponse {
   }
 
   // 투표 결과는 리턴하지 않는 생성자
-  public static VoteResponse fromExample(VoteEntity voteEntity,
-    List<CandidateEntity> candidateList
-  ) {
-    List<Vote> voteList = candidateList.stream().map(
+  public static VoteResponse fromExample(VoteEntity voteEntity) {
+    List<Vote> voteList = voteEntity.getCandidateEntity().stream().map(
       candidate -> Vote.builder()
         .candidateId(candidate.getCandidateId())
         .example(candidate.getExample())


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- **VoteEntity에서 List\<CandidateEntity\>를 조회할 수 있으므로 따로 조회하는 코드 삭제**
- **기존 이름의 Example이 모호하여 정적 팩토리 메서드명 수정**
  - fromExample **->** fromEntity
  - fromExampleAndVoteCount **->** fromEntityWithResult

## 스크린샷

## 주의사항

Closes #92 
