### PR TITLE
[feat] 경기 상세 정보 조회 API 구현

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/club/FixtureHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/club/FixtureHandler.java
@@ -1,8 +1,10 @@
 package com.service.sport_companion.api.component.club;
 
+import com.service.sport_companion.core.exception.GlobalException;
 import com.service.sport_companion.domain.entity.ClubsEntity;
 import com.service.sport_companion.domain.entity.FixturesEntity;
 import com.service.sport_companion.domain.model.dto.response.fixtures.Fixtures;
+import com.service.sport_companion.domain.model.type.FailedResultType;
 import com.service.sport_companion.domain.repository.FixturesRepository;
 import java.time.LocalDate;
 import java.util.List;
@@ -42,6 +44,7 @@ public class FixtureHandler {
   private List<Fixtures> mapToFixturesList(List<FixturesEntity> fixturesEntities) {
     return fixturesEntities.stream()
         .map(fixture -> new Fixtures(
+            fixture.getFixtureId(),
             fixture.getSeason(),
             fixture.getFixtureDate(),
             fixture.getFixtureTime(),
@@ -50,8 +53,18 @@ public class FixtureHandler {
             fixture.getAwayClub().getClubName(),
             fixture.getAwayScore(),
             fixture.getHomeClub().getClubStadium(),
+            fixture.getHomeClub().getStadiumAddress(),
             fixture.getNotes()
         ))
         .toList();
+  }
+
+  /**
+   * fixtureId와 일치하는 경기 일정 조회
+   */
+  public ClubsEntity findClubByFixtureId(Long fixtureId) {
+    return fixturesRepository.findById(fixtureId)
+        .map(FixturesEntity::getHomeClub)
+        .orElseThrow(() -> new GlobalException(FailedResultType.FIXTURE_NOT_FOUND));
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/club/FixtureHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/club/FixtureHandler.java
@@ -62,7 +62,7 @@ public class FixtureHandler {
   /**
    * fixtureId와 일치하는 경기 일정 조회
    */
-  public FixturesEntity findClubByFixtureId(Long fixtureId) {
+  public FixturesEntity findFixturesFixtureId(Long fixtureId) {
     return fixturesRepository.findById(fixtureId)
         .orElseThrow(() -> new GlobalException(FailedResultType.FIXTURE_NOT_FOUND));
   }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/club/FixtureHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/club/FixtureHandler.java
@@ -62,9 +62,8 @@ public class FixtureHandler {
   /**
    * fixtureId와 일치하는 경기 일정 조회
    */
-  public ClubsEntity findClubByFixtureId(Long fixtureId) {
+  public FixturesEntity findClubByFixtureId(Long fixtureId) {
     return fixturesRepository.findById(fixtureId)
-        .map(FixturesEntity::getHomeClub)
         .orElseThrow(() -> new GlobalException(FailedResultType.FIXTURE_NOT_FOUND));
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/club/RestaurantHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/club/RestaurantHandler.java
@@ -1,0 +1,25 @@
+package com.service.sport_companion.api.component.club;
+
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.model.dto.response.fixtures.Restaurant;
+import com.service.sport_companion.domain.repository.RestaurantRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RestaurantHandler {
+
+  private final RestaurantRepository restaurantRepository;
+
+  public List<Restaurant> findClubRestaurant(ClubsEntity club) {
+    return restaurantRepository.findAllByClub(club).stream()
+        .map(restaurantEntity -> new Restaurant(
+            restaurantEntity.getRestaurantName(),
+            restaurantEntity.getRestaurantAddress(),
+            restaurantEntity.getLat(),
+            restaurantEntity.getLnt()
+        )).toList();
+  }
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/club/TipsHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/club/TipsHandler.java
@@ -1,0 +1,25 @@
+package com.service.sport_companion.api.component.club;
+
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.model.dto.response.fixtures.Tips;
+import com.service.sport_companion.domain.repository.TipsRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TipsHandler {
+
+  private final TipsRepository tipsRepository;
+
+  public List<Tips> findClubTips(ClubsEntity clubs) {
+    return tipsRepository.findAllByClubs(clubs).stream()
+        .map(tips -> new Tips(
+            tips.getSeatName(),
+            tips.getTheme(),
+            tips.getSeatNum()
+        )).toList();
+  }
+
+}

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/FixturesController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/FixturesController.java
@@ -3,11 +3,13 @@ package com.service.sport_companion.api.controller;
 import com.service.sport_companion.api.service.FixturesService;
 import com.service.sport_companion.domain.model.annotation.CallUser;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.fixtures.FixtureDetails;
 import com.service.sport_companion.domain.model.dto.response.fixtures.Fixtures;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,15 +33,17 @@ public class FixturesController {
   // 경기 일정 조회
   @GetMapping
   public ResponseEntity<ResultResponse<List<Fixtures>>> getFixtureList(
-      @CallUser Long userId,
-      @RequestParam("year") String year,
-      @RequestParam("month") String month,
-      @RequestParam("day") String day) {
+      @CallUser Long userId, @RequestParam("date") String date) {
 
-    ResultResponse<List<Fixtures>> response = fixturesService.getFixtureList(userId, year, month, day);
+    ResultResponse<List<Fixtures>> response = fixturesService.getFixtureList(userId, date);
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  @GetMapping("/{fixtureId}")
+  public ResponseEntity<ResultResponse<FixtureDetails>> getFixtureDetails(
+      @PathVariable("fixtureId") Long fixtureId) {
 
-
+    ResultResponse<FixtureDetails> response = fixturesService.getFixtureDetails(fixtureId);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/FixturesService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/FixturesService.java
@@ -1,6 +1,7 @@
 package com.service.sport_companion.api.service;
 
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.fixtures.FixtureDetails;
 import com.service.sport_companion.domain.model.dto.response.fixtures.Fixtures;
 import java.util.List;
 
@@ -10,5 +11,7 @@ public interface FixturesService {
   ResultResponse<Void> crawlFixtures(String year);
 
   // 경기 일정 조회
-  ResultResponse<List<Fixtures>> getFixtureList(Long userId, String year, String month, String day);
+  ResultResponse<List<Fixtures>> getFixtureList(Long userId, String date);
+
+  ResultResponse<FixtureDetails> getFixtureDetails(Long fixtureId);
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
@@ -1,15 +1,19 @@
 package com.service.sport_companion.api.service.impl;
 
 import com.service.sport_companion.api.component.club.FixtureHandler;
+import com.service.sport_companion.api.component.club.RestaurantHandler;
 import com.service.sport_companion.api.component.club.SupportedClubsHandler;
+import com.service.sport_companion.api.component.club.TipsHandler;
 import com.service.sport_companion.api.component.crawl.CrawlFixtures;
 import com.service.sport_companion.api.service.FixturesService;
 import com.service.sport_companion.domain.entity.ClubsEntity;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
+import com.service.sport_companion.domain.model.dto.response.fixtures.FixtureDetails;
 import com.service.sport_companion.domain.model.dto.response.fixtures.Fixtures;
+import com.service.sport_companion.domain.model.dto.response.fixtures.Restaurant;
+import com.service.sport_companion.domain.model.dto.response.fixtures.Tips;
 import com.service.sport_companion.domain.model.type.SuccessResultType;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +27,8 @@ public class FixturesServiceImpl implements FixturesService {
   private final CrawlFixtures crawlFixtures;
   private final FixtureHandler fixtureHandler;
   private final SupportedClubsHandler supportedClubsHandler;
+  private final RestaurantHandler restaurantHandler;
+  private final TipsHandler tipsHandler;
 
   // 경기 일정 크롤링
   @Override
@@ -34,10 +40,8 @@ public class FixturesServiceImpl implements FixturesService {
 
   // 경기 일정 조회
   @Override
-  public ResultResponse<List<Fixtures>> getFixtureList(Long userId, String year, String month, String day) {
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    String formattedDate = year + "-" + month + "-" + day;
-    LocalDate fixtureDate = LocalDate.parse(formattedDate, formatter);
+  public ResultResponse<List<Fixtures>> getFixtureList(Long userId, String date) {
+    LocalDate fixtureDate = LocalDate.parse(date);
 
     ClubsEntity clubs = (userId != null) ? supportedClubsHandler.findSupportClubsByUserId(userId) : null;
 
@@ -47,5 +51,20 @@ public class FixturesServiceImpl implements FixturesService {
         : fixtureHandler.getAllFixturesList(fixtureDate);
 
     return new ResultResponse<>(SuccessResultType.SUCCESS_GET_ALL_FIXTURES, fixturesList);
+  }
+
+  @Override
+  public ResultResponse<FixtureDetails> getFixtureDetails(Long fixtureId) {
+    ClubsEntity club = fixtureHandler.findClubByFixtureId(fixtureId);
+
+    List<Restaurant> restaurants = restaurantHandler.findClubRestaurant(club);
+
+    List<Tips> tips = tipsHandler.findClubTips(club);
+
+    FixtureDetails fixtureDetails = new FixtureDetails(
+        restaurants, tips, club.getReservationSite().getSiteUrl()
+    );
+
+    return new ResultResponse<>(SuccessResultType.SUCCESS_GET_FIXTURES_DETAILS, fixtureDetails);
   }
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
@@ -7,6 +7,7 @@ import com.service.sport_companion.api.component.club.TipsHandler;
 import com.service.sport_companion.api.component.crawl.CrawlFixtures;
 import com.service.sport_companion.api.service.FixturesService;
 import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.entity.FixturesEntity;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
 import com.service.sport_companion.domain.model.dto.response.fixtures.FixtureDetails;
 import com.service.sport_companion.domain.model.dto.response.fixtures.Fixtures;
@@ -55,15 +56,17 @@ public class FixturesServiceImpl implements FixturesService {
 
   @Override
   public ResultResponse<FixtureDetails> getFixtureDetails(Long fixtureId) {
-    ClubsEntity club = fixtureHandler.findClubByFixtureId(fixtureId);
+    FixturesEntity fixtures = fixtureHandler.findClubByFixtureId(fixtureId);
 
-    List<Restaurant> restaurants = restaurantHandler.findClubRestaurant(club);
+    List<Restaurant> restaurants = restaurantHandler.findClubRestaurant(fixtures.getHomeClub());
 
-    List<Tips> tips = tipsHandler.findClubTips(club);
+    List<Tips> tips = tipsHandler.findClubTips(fixtures.getHomeClub());
 
-    FixtureDetails fixtureDetails = new FixtureDetails(
-        restaurants, tips, club.getReservationSite().getSiteUrl()
-    );
+    String siteUrl = fixtures.getFixtureDate().isBefore(LocalDate.now())
+        ? fixtures.getHomeClub().getReservationSite().getSiteUrl()
+        : null;
+
+    FixtureDetails fixtureDetails = new FixtureDetails(restaurants, tips, siteUrl);
 
     return new ResultResponse<>(SuccessResultType.SUCCESS_GET_FIXTURES_DETAILS, fixtureDetails);
   }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
@@ -56,7 +56,7 @@ public class FixturesServiceImpl implements FixturesService {
 
   @Override
   public ResultResponse<FixtureDetails> getFixtureDetails(Long fixtureId) {
-    FixturesEntity fixtures = fixtureHandler.findClubByFixtureId(fixtureId);
+    FixturesEntity fixtures = fixtureHandler.findFixturesFixtureId(fixtureId);
 
     List<Restaurant> restaurants = restaurantHandler.findClubRestaurant(fixtures.getHomeClub());
 

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/ClubsEntity.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/ClubsEntity.java
@@ -36,6 +36,8 @@ public class ClubsEntity {
 
   private String clubStadium;
 
+  private String stadiumAddress;
+
   private String emblemImg;
 
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/RestaurantEntity.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/RestaurantEntity.java
@@ -1,0 +1,36 @@
+package com.service.sport_companion.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "Restaurant")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class RestaurantEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long restaurantId;
+
+  @ManyToOne
+  @JoinColumn(name = "club_id", nullable = false)
+  private ClubsEntity club;
+
+  private String restaurantName;
+
+  private String restaurantAddress;
+
+  private Double lat;
+
+  private Double lnt;
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/TipsEntity.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/entity/TipsEntity.java
@@ -1,0 +1,35 @@
+package com.service.sport_companion.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "Tips")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class TipsEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long tipId;
+
+  @ManyToOne
+  @JoinColumn(name = "club_id", nullable = false)
+  private ClubsEntity clubs;
+
+  private String SeatName;
+
+  private String theme;
+
+  private String SeatNum;
+
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/fixtures/FixtureDetails.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/fixtures/FixtureDetails.java
@@ -1,0 +1,17 @@
+package com.service.sport_companion.domain.model.dto.response.fixtures;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FixtureDetails {
+
+  private List<Restaurant> restaurants;
+
+  private List<Tips> tips;
+
+  private String siteUrl;
+
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/fixtures/Fixtures.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/fixtures/Fixtures.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class Fixtures {
 
+  private Long fixtureId;
+
   private String season;
 
   private LocalDate fixtureDate;
@@ -24,6 +26,8 @@ public class Fixtures {
   private int awayScore;
 
   private String stadium;
+
+  private String stadiumAddress;
 
   private String notes;
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/fixtures/Restaurant.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/fixtures/Restaurant.java
@@ -1,0 +1,17 @@
+package com.service.sport_companion.domain.model.dto.response.fixtures;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Restaurant {
+
+  private String restaurantName;
+
+  private String restaurantAddress;
+
+  private Double lat;
+
+  private Double lnt;
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/fixtures/Tips.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/fixtures/Tips.java
@@ -1,0 +1,16 @@
+package com.service.sport_companion.domain.model.dto.response.fixtures;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class Tips {
+
+  private String SeatName;
+
+  private String theme;
+
+  private String SeatNum;
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -31,6 +31,7 @@ public enum SuccessResultType {
   // Fixtures
   SUCCESS_CRAWL_FIXTURE(HttpStatus.OK, "크롤링 성공"),
   SUCCESS_GET_ALL_FIXTURES(HttpStatus.OK, "모든 경기 일정 조회 성공"),
+  SUCCESS_GET_FIXTURES_DETAILS(HttpStatus.OK, "경기상세 정보 조회 성공"),
 
   // CustomTopic
   SUCCESS_CREATE_CUSTOM_TOPIC(HttpStatus.CREATED, "주제가 작성되었습니다."),

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/RestaurantRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/RestaurantRepository.java
@@ -1,0 +1,12 @@
+package com.service.sport_companion.domain.repository;
+
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.entity.RestaurantEntity;
+import com.service.sport_companion.domain.model.dto.response.fixtures.Restaurant;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantRepository extends JpaRepository<RestaurantEntity, Long> {
+
+  List<RestaurantEntity> findAllByClub(ClubsEntity club);
+}

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/TipsRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/TipsRepository.java
@@ -1,0 +1,14 @@
+package com.service.sport_companion.domain.repository;
+
+import com.service.sport_companion.domain.entity.ClubsEntity;
+import com.service.sport_companion.domain.entity.TipsEntity;
+import com.service.sport_companion.domain.model.dto.response.fixtures.Tips;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TipsRepository extends JpaRepository<TipsEntity, Long> {
+
+  List<TipsEntity> findAllByClubs(ClubsEntity clubs);
+}


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
경기 일정 조회 부분 수정
- 기존 날짜 전달 방식
   - year, month, day
- 변경 후 날짜 전달 방식
   - date (yyyy-mm-dd)  

clubEntity 필드 값 추가
- fixtureId
- stadiumAddress 

경기 상세 정보 조회 API 구현
- 홈팀 구단을 기준으로, 홈팀 구장의 상세 정보를 조회.
    - 구장 근처 맛집 리스트
    - 구장 좌석 꿀팁
    - 경기 예매 사이트 Url 
## 스크린샷

## 주의사항
- 아직 기획파트로 부터 데이터를 마저 전달 받지 못해서, 피그마에 있는 내용들로만 가지고, 성주님과 상의하여 API를 만들었는데, 기획 파트에서 확실하게 말씀해주시면, 그때 세부적으로 작업을 할 수 있을 것 같습니다..

Closes #86 
