### PR TITLE
[fix] WebDriver 빈대신 메서드로 생성

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/crawl/CrawlFixtures.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/crawl/CrawlFixtures.java
@@ -1,6 +1,7 @@
 package com.service.sport_companion.api.component.crawl;
 
 import com.service.sport_companion.api.component.club.ClubsFacade;
+import com.service.sport_companion.core.component.WebDriverHandler;
 import com.service.sport_companion.domain.entity.ClubsEntity;
 import com.service.sport_companion.domain.entity.FixturesEntity;
 import java.time.Duration;
@@ -32,9 +33,10 @@ import org.springframework.stereotype.Component;
 public class CrawlFixtures {
 
   private final ClubsFacade clubsFacade;
-  private final WebDriver driver;
+  private final WebDriverHandler webDriverHandler;
 
   public void crawlFixtures(String year) {
+    WebDriver driver = webDriverHandler.getDriver();
     WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
 
     Map<String, String> seriesMap = new HashMap<>();

--- a/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/news/MbcNewsCrawling.java
+++ b/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/news/MbcNewsCrawling.java
@@ -1,5 +1,6 @@
 package com.service.sport_companion.batch.news;
 
+import com.service.sport_companion.core.component.WebDriverHandler;
 import com.service.sport_companion.core.exception.GlobalException;
 import com.service.sport_companion.domain.entity.NewsEntity;
 import com.service.sport_companion.domain.model.type.FailedResultType;
@@ -34,7 +35,7 @@ import org.springframework.stereotype.Component;
 public class MbcNewsCrawling {
 
   private final String baseUrl = UrlType.MBC_NEWS_URL.getUrl();
-  private final WebDriver driver;
+  private final WebDriverHandler webDriverHandler;
 
   // 배치로 실행시킬 MBC News 크롤링 메인 작업
   @Transactional
@@ -42,6 +43,7 @@ public class MbcNewsCrawling {
     String url = baseUrl + "/more/search/?mainSearch=%EC%95%BC%EA%B5%AC";
     int pageSize = 5;
 
+    WebDriver driver = webDriverHandler.getDriver();
     driver.get(url);
 
     WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));

--- a/sport_companion/module-core/src/main/java/com/service/sport_companion/core/component/WebDriverHandler.java
+++ b/sport_companion/module-core/src/main/java/com/service/sport_companion/core/component/WebDriverHandler.java
@@ -40,7 +40,7 @@ public class WebDriverHandler {
   }
 
   // 배포 환경에서 WebDriver 생성해서 리턴
-  public WebDriver webDriverChrome() {
+  private WebDriver webDriverChrome() {
     WebDriver driver;
     try {
       driver = new RemoteWebDriver(new URL(SELENIUM_SERVER_URL), chromeOptions());
@@ -52,7 +52,7 @@ public class WebDriverHandler {
   }
 
   // 개발 환경에서 WebDriver 생성해서 리턴
-  public WebDriver webDriverSafari() {
+  private WebDriver webDriverSafari() {
     return new SafariDriver();
   }
 }

--- a/sport_companion/module-core/src/main/java/com/service/sport_companion/core/component/WebDriverHandler.java
+++ b/sport_companion/module-core/src/main/java/com/service/sport_companion/core/component/WebDriverHandler.java
@@ -10,13 +10,15 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.safari.SafariDriver;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class WebDriverHandler {
+
+  private final Environment environment;
 
   @Value("${selenium.server.url:default-for-dev}")
   private String SELENIUM_SERVER_URL;
@@ -29,11 +31,17 @@ public class WebDriverHandler {
     return options;
   }
 
+  public WebDriver getDriver() {
+    if (environment.acceptsProfiles(Profiles.of("prod"))) {
+      return webDriverChrome();
+    } else {
+      return webDriverSafari();
+    }
+  }
+
   // 배포 환경에서 WebDriver 생성해서 리턴
-  @Bean
-  @Profile("prod")
-  public RemoteWebDriver webDriverChrome() {
-    RemoteWebDriver driver;
+  public WebDriver webDriverChrome() {
+    WebDriver driver;
     try {
       driver = new RemoteWebDriver(new URL(SELENIUM_SERVER_URL), chromeOptions());
     } catch (MalformedURLException e) {
@@ -44,8 +52,6 @@ public class WebDriverHandler {
   }
 
   // 개발 환경에서 WebDriver 생성해서 리턴
-  @Bean
-  @Profile("dev")
   public WebDriver webDriverSafari() {
     return new SafariDriver();
   }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- **WebDriver 빈 주입에서 메서드 호출 방식으로 수정**
  - 기존 WebDriver 빈 생성 방식은 quit 하면 다시 생성되지 않으므로 두 번 이상 호출 시 오류 발생
  - dev, prod 환경에서 다른 WebDriver 사용을 위해 Enviroment에서 profile 확인


## 스크린샷

## 주의사항

Closes #108
