### PR TITLE
[feat] 구단 별 경기 일정 조회 메서드 구현

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtFilter.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtFilter.java
@@ -39,7 +39,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     // Bearer 시작 여부 및 null 값 검증
     if (tokenHeader == null || !tokenHeader.startsWith("Bearer ")) {
-      log.info("Token is not valid");
+      log.info("유효하지 않은 토큰 값");
       setResponse(response);
       return;
     }
@@ -67,7 +67,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
   // Access-Token 만료시 403 반환
   private void setResponse(HttpServletResponse response) throws IOException {
-    log.info("setResponse");
+    log.info("Response status : {}", HttpServletResponse.SC_FORBIDDEN);
     ObjectMapper objectMapper = new ObjectMapper();
     response.setStatus(HttpServletResponse.SC_FORBIDDEN);
     response.setContentType("application/json");
@@ -119,6 +119,7 @@ public class JwtFilter extends OncePerRequestFilter {
   private boolean isExcludedPath(AntPathMatcher pathMatcher, String requestURI) {
 
     return pathMatcher.match("/", requestURI)
+        || pathMatcher.match("/favicon.ico", requestURI)
         || pathMatcher.match("/api/v1/auth/**", requestURI)
         || pathMatcher.match("/api/v1/clubs/**", requestURI)
         || pathMatcher.match("/api/v1/news/**", requestURI)
@@ -131,7 +132,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
   public boolean isMatchingGetRequest(AntPathMatcher pathMatcher, String requestURI) {
 
-    return pathMatcher.match("/api/v1/fixture", requestURI)
+    return pathMatcher.match("/api/v1/fixture/**", requestURI)
         || pathMatcher.match("/api/v1/vote", requestURI)
         || pathMatcher.match("/api/v1/vote/result/prev", requestURI)
         || pathMatcher.match("/api/v1/topic", requestURI)

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtUtil.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/auth/jwt/JwtUtil.java
@@ -64,7 +64,7 @@ public class JwtUtil {
   }
 
   // 토큰 생성
-  public String createJwt(String type, Long userId, UserRole role) {
+  public String createJwt(String type, Long userId, String nickname, UserRole role) {
     long expirationTime = "access".equals(type)
         ? ACCESS_TOKEN_EXPIRE_TIME
         : REFRESH_TOKEN_EXPIRE_TIME;
@@ -72,6 +72,7 @@ public class JwtUtil {
     return Jwts.builder()
         .claim("type", type)
         .claim("userId", userId)
+        .claim("nickname", nickname)
         .claim("role", role.name())
         .notBefore(new Date(System.currentTimeMillis()))
         .expiration(new Date(System.currentTimeMillis() + expirationTime))

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/club/ClubsFacade.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/club/ClubsFacade.java
@@ -147,7 +147,7 @@ public class ClubsFacade {
     // 조건에 따라 경기 일정 조회
     List<Fixtures> fixtures = (clubs == null) ?
         Fixtures.of(fixturesRepository.findAllByFixtureDate(fixtureDate)) :
-        Fixtures.of(fixturesRepository.findSupportFixtures(fixtureDate, clubs));
+        Fixtures.of(fixturesRepository.findClubFixtures(fixtureDate, clubs));
 
     // 로그 출력
     if (clubs == null) {
@@ -157,6 +157,17 @@ public class ClubsFacade {
     }
 
     return fixtures;
+  }
+
+  /**
+   * 구단 별 경기 일정 조회
+   */
+  public List<Fixtures> getClubFixtureList(String clubName, LocalDate fixtureDate) {
+    log.info("날짜 '{}'와 구단 '{}'에 해당하는 경기 일정을 조회합니다.", fixtureDate, clubName);
+
+    ClubsEntity clubs = findByClubName(clubName);
+
+    return Fixtures.of(fixturesRepository.findClubFixtures(fixtureDate, clubs));
   }
 
   /**
@@ -207,4 +218,5 @@ public class ClubsFacade {
         ? fixtures.getHomeClub().getReservationSite()
         : null;
   }
+
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
@@ -51,14 +51,13 @@ public class SecurityConfig {
                 "/api/v1/auth/**",
                 "/api/v1/news/**",
                 "/api/v1/clubs/**",
-                "/api/v1/fixture/crawl",
                 "/favicon.ico").permitAll()
             .requestMatchers(HttpMethod.GET,
                 "/api/v1/topic/top5",
                 "/api/v1/topic",
                 "/api/v1/vote/result/prev",
                 "/api/v1/vote",
-                "/api/v1/fixture").permitAll()
+                "/api/v1/fixture/**").permitAll()
             .requestMatchers(
               "api/v1/vote/**").hasRole(UserRole.ADMIN.name())
             .anyRequest().authenticated());

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/FixturesController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/FixturesController.java
@@ -39,6 +39,14 @@ public class FixturesController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  @GetMapping("/club")
+  public ResponseEntity<ResultResponse<List<Fixtures>>> getFixtureList(
+      @RequestParam("clubName") String clubName, @RequestParam("date") String date) {
+
+    ResultResponse<List<Fixtures>> response = fixturesService.getClubFixtureList(clubName, date);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
   @GetMapping("/{fixtureId}")
   public ResponseEntity<ResultResponse<FixtureDetails>> getFixtureDetails(
       @PathVariable("fixtureId") Long fixtureId) {

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/FixturesService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/FixturesService.java
@@ -13,5 +13,10 @@ public interface FixturesService {
   // 경기 일정 조회
   ResultResponse<List<Fixtures>> getFixtureList(Long userId, String date);
 
+  // 구단 별 경기 일정 조회
+  ResultResponse<List<Fixtures>> getClubFixtureList(String clubName, String date);
+
+  // 경기 상세 정보
   ResultResponse<FixtureDetails> getFixtureDetails(Long fixtureId);
+
 }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/AuthServiceImpl.java
@@ -72,8 +72,8 @@ public class AuthServiceImpl implements AuthService {
     // 기존 회원 - 로그인 성공
     log.info("로그인 성공 - userId: {}", user.getUserId());
 
-    String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
-    String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getRole());
+    String access = jwtUtil.createJwt("access", user.getUserId(), user.getNickname(), user.getRole());
+    String refresh = jwtUtil.createJwt("refresh", user.getUserId(), user.getNickname(),user.getRole());
 
     response.addHeader(TokenType.ACCESS.getValue(), access);
     response.addHeader(TokenType.REFRESH.getValue(), refresh);
@@ -140,7 +140,7 @@ public class AuthServiceImpl implements AuthService {
     Long userId = jwtUtil.getUserId(refreshToken);
     UsersEntity user = userHandler.findByUserId(userId);
 
-    String access = jwtUtil.createJwt("access", user.getUserId(), user.getRole());
+    String access = jwtUtil.createJwt("access", user.getUserId(), user.getNickname(), user.getRole());
     response.addHeader(TokenType.ACCESS.getValue(), access);
 
     log.info("토큰 재발급 성공 - userId: {}", user.getUserId());

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/impl/FixturesServiceImpl.java
@@ -58,6 +58,24 @@ public class FixturesServiceImpl implements FixturesService {
   }
 
   /**
+   * 특정 구단의 경기 정보를 조회
+   *
+   * @param clubName 구단 명
+   * @param date   조회 날짜 (yyyy-MM-dd 형식)
+   */
+  @Override
+  public ResultResponse<List<Fixtures>> getClubFixtureList(String clubName, String date) {
+    log.info("조회할 구단 : {}, 경기 날짜: {}",clubName, date);
+
+    LocalDate fixtureDate = LocalDate.parse(date);
+
+    List<Fixtures> fixturesList = clubsFacade.getClubFixtureList(clubName, fixtureDate);
+
+    log.info("{} 년도 {} 경기 일정 조회 성공",clubName, date);
+    return new ResultResponse<>(SuccessResultType.SUCCESS_GET_CLUB_FIXTURES, fixturesList);
+  }
+
+  /**
    * 특정 경기의 상세 정보를 조회
    *
    * @param fixtureId 경기 ID

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -32,6 +32,7 @@ public enum SuccessResultType {
   // Fixtures
   SUCCESS_CRAWL_FIXTURE(HttpStatus.OK, "크롤링 성공"),
   SUCCESS_GET_ALL_FIXTURES(HttpStatus.OK, "모든 경기 일정 조회 성공"),
+  SUCCESS_GET_CLUB_FIXTURES(HttpStatus.OK, "구단별 경기 일정 조회 성공"),
   SUCCESS_GET_FIXTURES_DETAILS(HttpStatus.OK, "경기상세 정보 조회 성공"),
 
   // CustomTopic

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/FixturesRepository.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/repository/FixturesRepository.java
@@ -17,10 +17,9 @@ public interface FixturesRepository extends JpaRepository<FixturesEntity, Long> 
   @Query("SELECT f FROM Fixtures f "
       + "WHERE f.fixtureDate = :fixtureDate "
       + "AND (f.homeClub = :clubs OR f.awayClub = :clubs)")
-  List<FixturesEntity> findSupportFixtures(
+  List<FixturesEntity> findClubFixtures(
       @Param("fixtureDate") LocalDate fixtureDate,
       @Param("clubs") ClubsEntity clubs
   );
-
 
 }


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 구단 별 경기 일정 조회 API 구현
- SecurityConfig, JwtFilter 구단 경기 일정 조회 요청 경로 허용 설정
- FixtureController
   - QueryString으로 구단명과, 날짜를 입력받아 해당 데이터와 일치하는 경기 일정 반환
- FixtureService & FixtureServiceImpl & ClubsFacade
   -   구단 명과 일치하는 ClubsEntity 조회 후, 해당 데이터와 일치하는 경기 일정 반환

## 스크린샷

## 주의사항

Closes #111 
