### PR TITLE
[feat] 이번주 투표 API 조회 방식 수정

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/vote/UserVoteHandler.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/component/vote/UserVoteHandler.java
@@ -13,6 +13,9 @@ public class UserVoteHandler {
   private final UserVoteRepository userVoteRepository;
 
   public boolean isVotedToday(Long userId) {
+    if (userId == null) {
+      return false;
+    }
     return userVoteRepository.findTodayVote(userId, LocalDate.now()).isPresent();
   }
 

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/VoteController.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/controller/VoteController.java
@@ -5,7 +5,6 @@ import com.service.sport_companion.domain.model.annotation.CallUser;
 import com.service.sport_companion.domain.model.dto.request.vote.CreateVoteDto;
 import com.service.sport_companion.domain.model.dto.response.PageResponse;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
-import com.service.sport_companion.domain.model.dto.response.vote.CheckVotedResponse;
 import com.service.sport_companion.domain.model.dto.response.vote.VoteResponse;
 import com.service.sport_companion.domain.model.type.SortType;
 import lombok.RequiredArgsConstructor;
@@ -56,15 +55,8 @@ public class VoteController {
   }
 
   @GetMapping
-  public ResponseEntity<ResultResponse<VoteResponse>> getThisWeekVote() {
-    ResultResponse<VoteResponse> response = voteService.getThisWeekVote();
-
-    return new ResponseEntity<>(response, response.getStatus());
-  }
-
-  @GetMapping("/result")
-  public ResponseEntity<ResultResponse<VoteResponse>> getThisWeekVoteResult(@CallUser Long userId) {
-    ResultResponse<VoteResponse> response = voteService.getThisWeekVoteResult(userId);
+  public ResponseEntity<ResultResponse<VoteResponse>> getThisWeekVote(@CallUser Long userId) {
+    ResultResponse<VoteResponse> response = voteService.getThisWeekVote(userId);
 
     return new ResponseEntity<>(response, response.getStatus());
   }
@@ -76,13 +68,6 @@ public class VoteController {
     Pageable pageable
   ) {
     ResultResponse<PageResponse<VoteResponse>> response = voteService.getPrevVoteResult(userId, sortType, pageable);
-
-    return new ResponseEntity<>(response, response.getStatus());
-  }
-
-  @GetMapping("/user")
-  public ResponseEntity<ResultResponse<CheckVotedResponse>> checkUserVoted(@CallUser Long userId) {
-    ResultResponse<CheckVotedResponse> response = voteService.checkUserVoted(userId);
 
     return new ResponseEntity<>(response, response.getStatus());
   }

--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/VoteService.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/service/VoteService.java
@@ -3,7 +3,6 @@ package com.service.sport_companion.api.service;
 import com.service.sport_companion.domain.model.dto.request.vote.CreateVoteDto;
 import com.service.sport_companion.domain.model.dto.response.PageResponse;
 import com.service.sport_companion.domain.model.dto.response.ResultResponse;
-import com.service.sport_companion.domain.model.dto.response.vote.CheckVotedResponse;
 import com.service.sport_companion.domain.model.dto.response.vote.VoteResponse;
 import com.service.sport_companion.domain.model.type.SortType;
 import org.springframework.data.domain.Pageable;
@@ -16,13 +15,9 @@ public interface VoteService {
 
   ResultResponse<Void> deleteVote(Long userId, Long voteId);
 
-  ResultResponse<VoteResponse> getThisWeekVote();
-
-  ResultResponse<VoteResponse> getThisWeekVoteResult(Long userId);
+  ResultResponse<VoteResponse> getThisWeekVote(Long userId);
 
   ResultResponse<PageResponse<VoteResponse>> getPrevVoteResult(Long userId, SortType sortType, Pageable pageable);
-
-  ResultResponse<CheckVotedResponse> checkUserVoted(Long userId);
 
   ResultResponse<VoteResponse> vote(Long userId, Long voteId, Long candidateId);
 }

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/vote/VoteResponse.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/vote/VoteResponse.java
@@ -2,6 +2,7 @@ package com.service.sport_companion.domain.model.dto.response.vote;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.service.sport_companion.domain.entity.VoteEntity;
+import com.service.sport_companion.domain.model.type.VoteResultType;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -14,6 +15,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class VoteResponse {
+
+  private String resultType;
 
   private Long voteId;
 
@@ -53,6 +56,7 @@ public class VoteResponse {
     ).toList();
 
     return VoteResponse.builder()
+      .resultType(VoteResultType.VOTE.name())
       .voteId(voteEntity.getVoteId())
       .startDate(voteEntity.getStartDate())
       .endDate(voteEntity.getEndDate())
@@ -67,6 +71,7 @@ public class VoteResponse {
     Long myVote
   ) {
     VoteResponse voteResponse = VoteResponse.builder()
+      .resultType(VoteResultType.RESULT.name())
       .voteId(voteEntity.getVoteId())
       .startDate(voteEntity.getStartDate())
       .endDate(voteEntity.getEndDate())

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/SuccessResultType.java
@@ -46,6 +46,7 @@ public enum SuccessResultType {
   SUCCESS_MODIFY_VOTE(HttpStatus.OK, "투표가 수정되었습니다."),
   SUCCESS_DELETE_VOTE(HttpStatus.OK, "투표가 삭제되었습니다."),
   SUCCESS_GET_VOTE(HttpStatus.OK, "투표를 성공적으로 조회했습니다."),
+  SUCCESS_GET_VOTE_RESULT(HttpStatus.OK, "투표 결과를 성공적으로 조회했습니다."),
   SUCCESS_CHECK_VOTED(HttpStatus.OK, "투표 여부를 확인했습니다."),
   SUCCESS_VOTING(HttpStatus.OK, "투표를 완료했습니다."),
 

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/VoteResultType.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/type/VoteResultType.java
@@ -1,0 +1,10 @@
+package com.service.sport_companion.domain.model.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum VoteResultType {
+  VOTE, RESULT
+}


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 기존 3개의 API(/vote, /vote/result, /vote/user)를 통해 조회하던 이번주 투표 기능을 1개의 API(/vote)로 수정
  - 효율성을 위해 한번의 API로 투표 데이터를 가져올 수 있도록 함
  - 당일 투표 여부 확인 후 투표했으면 결과, 안 했으면 투표 주제만 반환
- 반환된 타입 추가
  - 투표만 반환하면 VOTE, 결과를 반환하면 RESULT를 반환

## 스크린샷

## 주의사항

Closes #113
