### PR TITLE
[fix] 투표하기 권한 사용자 허용

### DIFF
--- a/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
+++ b/sport_companion/module-api/src/main/java/com/service/sport_companion/api/config/SecurityConfig.java
@@ -59,7 +59,8 @@ public class SecurityConfig {
                 "/api/v1/vote",
                 "/api/v1/fixture/**").permitAll()
             .requestMatchers(
-              "api/v1/vote/**").hasRole(UserRole.ADMIN.name())
+              "api/v1/vote/*",
+              "api/v1/vote").hasRole(UserRole.ADMIN.name())
             .anyRequest().authenticated());
 
     http


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 투표하기 API가 관리자만 호출할 수 있어 일반 USER가 사용할 수 있도록 수정
  - **원인** : 관리자 권한인 [_POST /vote_], [_PUT /vote/{id}_], [_DELETE /vote/{id}_]를 매핑하기 위해 **\/vote/**\**를 사용했으나 투표하기 api인 [_POST /vote/{id}/candidate/{id}_]도 매핑되어 관리자만 사용할 수 있게 됨
  - **해결** : 구체적으로 /vote/*, /vote를 관리자 권한으로 설정

## 스크린샷

## 주의사항
- endpoint만으로 설정하기에 복잡하여 API가 추가될 때마다 오류가 발생될 가능성이 있어 어노테이션으로 권한 설정하는 방식으로 수정이 필요해 보임

Closes #116
