### PR TITLE
[fix] 크롤링 스케줄링 timezone 설정

### DIFF
--- a/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/component/BatchScheduler.java
+++ b/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/component/BatchScheduler.java
@@ -16,7 +16,7 @@ public class BatchScheduler {
   private final Job mbcCrawlingJob;
 
   // 매일 11:50, 23:50 mbcCrawlingJob 수행
-  @Scheduled(cron = "0 50 11,23 * * *")
+  @Scheduled(cron = "0 50 11,23 * * *", zone = "Asia/Seoul")
   public void scheduleMbcCrawlingJob() throws Exception {
     JobParameters jobParameters = new JobParametersBuilder()
       .addString("timestamp", String.valueOf(System.currentTimeMillis()))

--- a/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/news/MbcNewsCrawling.java
+++ b/sport_companion/module-batch/src/main/java/com/service/sport_companion/batch/news/MbcNewsCrawling.java
@@ -9,6 +9,7 @@ import com.service.sport_companion.domain.model.type.UrlType;
 import jakarta.transaction.Transactional;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -104,7 +105,7 @@ public class MbcNewsCrawling {
     List<NewsEntity> newsItemList = new ArrayList<>();
     for (Element item : items) {
       String newsDate = item.select("a > .txt_w > .sub > .date").text().trim();
-      String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+      String today = LocalDate.now(ZoneId.of("Asia/Seoul")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
       if (!newsDate.equals(today)) break;
 
       String newsLink = item.select("a").attr("href");

--- a/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/news/NewsResponseDto.java
+++ b/sport_companion/module-domain/src/main/java/com/service/sport_companion/domain/model/dto/response/news/NewsResponseDto.java
@@ -17,7 +17,7 @@ public class NewsResponseDto {
   private String headline;
   private String newsLink;
   private String thumbnail;
-  @JsonFormat(pattern = "yyyy-MM-dd hh:mm")
+  @JsonFormat(pattern = "yyyy-MM-dd hh:mm", timezone = "Asia/Seoul")
   private LocalDateTime newsDateTime;
 
   public static NewsResponseDto from(NewsEntity newsEntity) {


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용
- 서버 시간이 UTC 기준이라 지정한 시간(11:50/23:50분)에 배치 작업이 실행되지 않아 timezone을 Asia/Seoul으로 별도 설정


## 스크린샷
![image](https://github.com/user-attachments/assets/55484d7a-1ee4-4641-a861-87230f3147c9)
(서버 시간 설정)

## 주의사항
- 서버 시간을 Asia/Seoul로 바꾸는 방법도 있지만 여러 문제 발생 가능성을 고려해서 스케줄링 timezone 변경

Closes #118
